### PR TITLE
feat: limit groups on login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,9 @@ AD_USER_FILTER=(objectClass=user)
 AD_GROUP_FILTER=(objectClass=group)
 AD_SEARCH_FILTER=(objectClass=*)
 
+# Maximum entries any single LDAP search may return, applied as the LDAP size limit.
+AD_MAX_SEARCH_RESULTS=200
+
 # Optional: Restrict searches to a specific OU (falls back to AD_BASE_DN if empty)
 # AD_SEARCH_BASE_DN=OU=Corporate,dc=example,dc=com
 

--- a/README.md
+++ b/README.md
@@ -152,14 +152,35 @@ curl -k -X PUT https://localhost:8080/api/v1/users \
   }'
 ```
 
-#### Get All Groups
+#### Search Groups
+
+A `query` (minimum 2 characters) or an explicit `filter` is **required**. Listing every
+group is not supported: it walks the entire directory and is prohibitively expensive on
+real domains. `query` matches `cn` and `sAMAccountName` as a substring, so partial input
+returns partial matches. Results are capped by `AD_MAX_SEARCH_RESULTS`.
+
 ```bash
-curl -k https://localhost:8080/api/v1/groups \
+curl -k "https://localhost:8080/api/v1/groups?query=admins" \
   -H "X-Session-ID: your-session-id"
 
 # With optional baseDN
-curl -k "https://localhost:8080/api/v1/groups?baseDN=ou=Groups,dc=example,dc=com" \
+curl -k "https://localhost:8080/api/v1/groups?query=admins&baseDN=ou=Groups,dc=example,dc=com" \
   -H "X-Session-ID: your-session-id"
+```
+
+Omitting both `query` and `filter` returns `400`.
+
+#### Resolve Groups by DN
+
+Looks up a known set of groups in a single search. Used by the UI to show a user's own
+memberships without listing the directory. Unlike `/groups`, this is not gated by
+`AD_SEARCH_ALLOWED_GROUPS`, since the request is bounded by the DNs supplied.
+
+```bash
+curl -k -X POST https://localhost:8080/api/v1/groups/resolve \
+  -H "Content-Type: application/json" \
+  -H "X-Session-ID: your-session-id" \
+  -d '{"dns":["CN=Developers,OU=Groups,DC=example,DC=com"]}'
 ```
 
 #### Add User to Group
@@ -235,6 +256,7 @@ Response:
 | AD_GROUP_FILTER | LDAP filter for groups | (objectClass=group) |
 | AD_SEARCH_FILTER | LDAP filter for general searches | (objectClass=*) |
 | AD_SEARCH_BASE_DN | Restrict searches to a specific OU (falls back to AD_BASE_DN if empty) | |
+| AD_MAX_SEARCH_RESULTS | Maximum entries returned by any single LDAP search (LDAP size limit) | 200 |
 | AD_EXCLUDED_OBJECTS | Semicolon-separated list of DN path fragments (OUs, CN containers) to exclude from results | |
 | AD_EXCLUDED_GROUPS | Semicolon-separated list of group CNs or DNs to exclude from results | |
 | AD_SEARCH_ALLOWED_GROUPS | Semicolon-separated group CNs or DNs allowed to use `/api/v1/search`; empty allows all authenticated users | |

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,10 @@ type ADConfig struct {
 	ExcludedObjects []string
 	// ExcludedGroups is a list of group CNs or DNs that are filtered out of group results.
 	ExcludedGroups []string
+	// MaxSearchResults caps the number of entries any single LDAP search may return.
+	// It is passed as the LDAP size limit, so the directory stops sending at the cap
+	// rather than the server discarding a large result after transferring it.
+	MaxSearchResults int
 	// SearchAllowedGroups is a list of group CNs or DNs whose members may use the search endpoint.
 	// If empty, search is available to every authenticated user.
 	SearchAllowedGroups []string
@@ -96,6 +100,7 @@ func Load() (*Config, error) {
 			SearchFilter:        getEnv("AD_SEARCH_FILTER", "(objectClass=*)"),
 			SearchBaseDN:        getEnv("AD_SEARCH_BASE_DN", ""),
 			ExcludedObjects:     getDNSliceEnv("AD_EXCLUDED_OBJECTS", nil),
+			MaxSearchResults:    getIntEnv("AD_MAX_SEARCH_RESULTS", 200),
 			ExcludedGroups:      getDNSliceEnv("AD_EXCLUDED_GROUPS", nil),
 			SearchAllowedGroups: getDNSliceEnv("AD_SEARCH_ALLOWED_GROUPS", nil),
 			CACertPath:          getEnv("AD_CA_CERT_PATH", ""),

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -24,8 +24,22 @@ const (
 	errMsgSessionNotFound    = "Session not found"
 	errMsgInvalidRequestBody = "Invalid request body"
 	errMsgSearchNotPermitted = "Search is not permitted for this user"
+	errMsgQueryRequired      = "A query or filter is required; listing all groups is not supported"
 	logKeyUserDN             = "userDN"
+
+	// minGroupQueryLen mirrors the UI's debounce threshold. Shorter queries match
+	// most of the directory, which is the unbounded listing this endpoint refuses.
+	minGroupQueryLen = 2
+
+	// maxResolveDNs caps a single membership-resolution request. A user in more
+	// groups than this is well outside normal, and the filter would get unwieldy.
+	maxResolveDNs = 500
 )
+
+// groupAttributes are the attributes read for group listings and lookups.
+// Deliberately excludes "member": on large groups that array holds every member DN
+// and dominates the response size, and no consumer of these endpoints reads it.
+var groupAttributes = []string{"dn", "cn", "sAMAccountName", "description", "groupType", "distinguishedName"} //nolint:goconst // LDAP schema attribute names, not app-level constants
 
 // Handler holds dependencies for HTTP handlers
 type Handler struct {
@@ -265,16 +279,33 @@ func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 		baseDN = h.config.AD.GetSearchBaseDN()
 	}
 
-	// query builds a safe escaped filter; falls back to filter param, then config default.
-	filter := h.config.AD.GroupFilter
-	if q := r.URL.Query().Get("query"); q != "" {
-		escaped := ldap.EscapeFilter(q)
+	// A query (or an explicit filter) is mandatory: an unfiltered listing walks every
+	// group under the base DN, which is prohibitively expensive on real directories.
+	query := strings.TrimSpace(r.URL.Query().Get("query"))
+	explicitFilter := r.URL.Query().Get("filter")
+	if query == "" && explicitFilter == "" {
+		writeJSON(w, http.StatusBadRequest, models.GroupsResponse{
+			Success: false,
+			Error:   errMsgQueryRequired,
+		})
+		return
+	}
+	if query != "" && len([]rune(query)) < minGroupQueryLen {
+		writeJSON(w, http.StatusBadRequest, models.GroupsResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Query must be at least %d characters", minGroupQueryLen),
+		})
+		return
+	}
+
+	// query builds a safe escaped filter; an explicit filter is used verbatim.
+	filter := explicitFilter
+	if query != "" {
+		escaped := ldap.EscapeFilter(query)
 		filter = fmt.Sprintf(
 			"(&%s(|(cn=*%s*)(sAMAccountName=*%s*)))",
 			h.config.AD.GroupFilter, escaped, escaped,
 		)
-	} else if f := r.URL.Query().Get("filter"); f != "" {
-		filter = f
 	}
 
 	// Search for groups
@@ -282,9 +313,9 @@ func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 		baseDN,
 		ldap.ScopeWholeSubtree,
 		ldap.NeverDerefAliases,
-		0, 0, false,
+		h.config.AD.MaxSearchResults, 0, false,
 		filter,
-		[]string{"dn", "cn", "sAMAccountName", "description", "groupType", "member", "memberOf", "distinguishedName"}, //nolint:goconst // LDAP schema attribute names, not app-level constants
+		groupAttributes,
 		nil,
 	)
 
@@ -297,24 +328,116 @@ func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	groups := make([]*models.Group, 0, len(sr.Entries))
-	for _, entry := range sr.Entries {
+	groups := h.entriesToGroups(sr.Entries)
+
+	writeJSON(w, http.StatusOK, models.GroupsResponse{
+		Success: true,
+		Groups:  groups,
+		Count:   len(groups),
+	})
+}
+
+// entriesToGroups maps LDAP entries to group models, dropping excluded containers and
+// groups. Members and MemberOf are intentionally left unset: groupAttributes does not
+// request them, since they are unused here and costly on large groups.
+func (h *Handler) entriesToGroups(entries []*ldap.Entry) []*models.Group {
+	groups := make([]*models.Group, 0, len(entries))
+	for _, entry := range entries {
 		cn := entry.GetAttributeValue("cn")
 		if h.isExcludedDN(entry.DN) || h.isExcludedGroup(cn, entry.DN) {
 			continue
 		}
-		group := &models.Group{
+		groups = append(groups, &models.Group{
 			DN:                entry.DN,
 			CN:                cn,
 			SAMAccountName:    entry.GetAttributeValue("sAMAccountName"),
 			Description:       entry.GetAttributeValue("description"),
 			GroupType:         entry.GetAttributeValue("groupType"),
-			Members:           entry.GetAttributeValues("member"),
-			MemberOf:          entry.GetAttributeValues("memberOf"),
 			DistinguishedName: entry.GetAttributeValue("distinguishedName"),
-		}
-		groups = append(groups, group)
+		})
 	}
+	return groups
+}
+
+// ResolveGroups looks up a specific set of group DNs in one search. It exists so the UI
+// can decorate a user's own memberships with names and descriptions without listing the
+// whole directory. The request is bounded by the caller's group count, so unlike
+// GetAllGroups it is not gated by the search allow-list.
+func (h *Handler) ResolveGroups(w http.ResponseWriter, r *http.Request) {
+	sess := middleware.GetSessionFromContext(r.Context())
+	if sess == nil {
+		writeJSON(w, http.StatusUnauthorized, models.GroupsResponse{
+			Success: false,
+			Error:   errMsgSessionNotFound,
+		})
+		return
+	}
+
+	var req models.ResolveGroupsRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, models.GroupsResponse{
+			Success: false,
+			Error:   errMsgInvalidRequestBody,
+		})
+		return
+	}
+
+	// Keep only well-formed, non-duplicate DNs. Malformed input is skipped rather than
+	// rejected outright so one bad memberOf value cannot break the whole page.
+	seen := make(map[string]struct{}, len(req.DNs))
+	clauses := make([]string, 0, len(req.DNs))
+	for _, dn := range req.DNs {
+		dn = strings.TrimSpace(dn)
+		if dn == "" {
+			continue
+		}
+		key := strings.ToLower(dn)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		if _, err := ldap.ParseDN(dn); err != nil {
+			slog.Debug("Skipping malformed DN in group resolve request", "dn", dn, "error", err)
+			continue
+		}
+		seen[key] = struct{}{}
+		clauses = append(clauses, fmt.Sprintf("(distinguishedName=%s)", ldap.EscapeFilter(dn)))
+		if len(clauses) >= maxResolveDNs {
+			slog.Warn("Group resolve request truncated at cap",
+				"username", sess.Username, "requested", len(req.DNs), "cap", maxResolveDNs)
+			break
+		}
+	}
+
+	if len(clauses) == 0 {
+		writeJSON(w, http.StatusOK, models.GroupsResponse{
+			Success: true,
+			Groups:  []*models.Group{},
+			Count:   0,
+		})
+		return
+	}
+
+	filter := fmt.Sprintf("(&%s(|%s))", h.config.AD.GroupFilter, strings.Join(clauses, ""))
+	searchReq := ldap.NewSearchRequest(
+		h.config.AD.GetSearchBaseDN(),
+		ldap.ScopeWholeSubtree,
+		ldap.NeverDerefAliases,
+		len(clauses), 0, false,
+		filter,
+		groupAttributes,
+		nil,
+	)
+
+	sr, err := sess.Conn.Search(searchReq)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, models.GroupsResponse{
+			Success: false,
+			Error:   fmt.Sprintf("Failed to resolve groups: %v", err),
+		})
+		return
+	}
+
+	groups := h.entriesToGroups(sr.Entries)
 
 	writeJSON(w, http.StatusOK, models.GroupsResponse{
 		Success: true,
@@ -632,6 +755,11 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(attributes) == 0 {
 		attributes = []string{"*"}
+	}
+	// Clamp to the configured cap: an unset (0) or oversized client limit would
+	// otherwise let a single request pull the whole directory.
+	if max := h.config.AD.MaxSearchResults; max > 0 && (sizeLimit <= 0 || sizeLimit > max) {
+		sizeLimit = max
 	}
 
 	// Perform LDAP search

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +15,9 @@ import (
 	"adel/models"
 	"adel/session"
 )
+
+// testUsername is the session username shared by handler tests.
+const testUsername = "testuser"
 
 func TestIsUserEnabled(t *testing.T) {
 	tests := []struct {
@@ -80,6 +84,7 @@ func TestFiletimeToUnixTime(t *testing.T) {
 		got := filetimeToUnixTime("132500000000000000")
 		if got == nil {
 			t.Fatal("filetimeToUnixTime() returned nil for valid filetime")
+			return
 		}
 		// Should be a date around 2020
 		if got.Year() < 2020 || got.Year() > 2021 {
@@ -279,7 +284,7 @@ func TestSearchForbiddenOutsideAllowedGroups(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?query=user", nil)
 	sess := &session.Session{
-		Username: "testuser",
+		Username: testUsername,
 		MemberOf: []string{"CN=Employees,OU=Groups,DC=example,DC=com"},
 	}
 	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
@@ -327,6 +332,7 @@ func TestFiletimeToUnixTimeUTC(t *testing.T) {
 	got := filetimeToUnixTime("132500000000000000")
 	if got == nil {
 		t.Fatal("expected non-nil time")
+		return
 	}
 	if got.Location() != time.UTC {
 		t.Errorf("location = %v, want UTC", got.Location())
@@ -343,7 +349,7 @@ func TestGetAllGroupsForbiddenOutsideAllowedGroups(t *testing.T) {
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/groups?query=infra", nil)
 	sess := &session.Session{
-		Username: "testuser",
+		Username: testUsername,
 		MemberOf: []string{"CN=Employees,OU=Groups,DC=example,DC=com"},
 	}
 	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
@@ -360,5 +366,83 @@ func TestGetAllGroupsForbiddenOutsideAllowedGroups(t *testing.T) {
 	}
 	if response.Success || response.Error == "" {
 		t.Errorf("response = %+v, want unsuccessful response with an error", response)
+	}
+}
+
+func TestGetAllGroupsRejectsUnboundedListing(t *testing.T) {
+	// An allowed user must still not be able to list the whole directory: the query
+	// requirement is a cost control, independent of the search allow-list.
+	cfg := &config.Config{AD: config.ADConfig{GroupFilter: "(objectClass=group)"}}
+	h := NewHandler(cfg, nil)
+
+	tests := []struct {
+		name string
+		url  string
+	}{
+		{"no query", "/api/v1/groups"},
+		{"empty query", "/api/v1/groups?query="},
+		{"whitespace query", "/api/v1/groups?query=%20%20"},
+		{"query below minimum length", "/api/v1/groups?query=a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
+			sess := &session.Session{Username: testUsername}
+			ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
+			rr := httptest.NewRecorder()
+
+			h.GetAllGroups(rr, req.WithContext(ctx))
+
+			if rr.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
+			}
+			var response models.GroupsResponse
+			if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+				t.Fatalf("failed to decode response: %v", err)
+			}
+			if response.Success || response.Error == "" {
+				t.Errorf("response = %+v, want unsuccessful response with an error", response)
+			}
+		})
+	}
+}
+
+func TestResolveGroupsEmptyInputSkipsSearch(t *testing.T) {
+	// No valid DNs means no LDAP search, so a nil session connection must not panic.
+	cfg := &config.Config{AD: config.ADConfig{GroupFilter: "(objectClass=group)"}}
+	h := NewHandler(cfg, nil)
+
+	body := strings.NewReader(`{"dns":["","   ","not-a-valid-dn"]}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/groups/resolve", body)
+	sess := &session.Session{Username: testUsername}
+	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
+	rr := httptest.NewRecorder()
+
+	h.ResolveGroups(rr, req.WithContext(ctx))
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var response models.GroupsResponse
+	if err := json.NewDecoder(rr.Body).Decode(&response); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !response.Success || response.Count != 0 {
+		t.Errorf("response = %+v, want successful empty response", response)
+	}
+}
+
+func TestResolveGroupsRequiresSession(t *testing.T) {
+	h := NewHandler(&config.Config{}, nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/groups/resolve",
+		strings.NewReader(`{"dns":[]}`))
+	rr := httptest.NewRecorder()
+
+	h.ResolveGroups(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -176,6 +176,7 @@ func setupRouter(handler *handlers.Handler, sessionMgr *session.Manager, cfg *co
 
 	// Group routes
 	protected.HandleFunc("/groups", handler.GetAllGroups).Methods(http.MethodGet)
+	protected.HandleFunc("/groups/resolve", handler.ResolveGroups).Methods(http.MethodPost)
 	protected.HandleFunc("/groups/add-member", handler.AddUserToGroup).Methods(http.MethodPost)
 	protected.HandleFunc("/groups/remove-member", handler.RemoveUserFromGroup).Methods(http.MethodPost, http.MethodDelete)
 

--- a/models/models.go
+++ b/models/models.go
@@ -130,6 +130,12 @@ type UserResponse struct {
 	Error   string `json:"error,omitempty"`
 }
 
+// ResolveGroupsRequest asks for details of a specific set of groups by DN, so callers
+// can enrich known memberships without listing the directory.
+type ResolveGroupsRequest struct {
+	DNs []string `json:"dns"`
+}
+
 // GroupsResponse represents groups list response
 type GroupsResponse struct {
 	Success bool     `json:"success"`

--- a/web/src/components/GroupMembership.tsx
+++ b/web/src/components/GroupMembership.tsx
@@ -48,24 +48,25 @@ export function GroupMembership({ user, onUpdate }: GroupMembershipProps) {
     return match ? match[1] : dn;
   };
 
-  const loadAllGroups = useCallback(async () => {
-    // Group listing is gated by the same allow-list as search; skip the call for
-    // users who would receive a 403. Their own groups still render from memberOf,
-    // just without the descriptions this lookup would have supplied.
-    if (!canSearch) {
+  // Resolves only the groups this user belongs to, rather than listing the directory.
+  // Purely decorative: it supplies descriptions the DN-derived fallback below lacks,
+  // so a failure degrades the table rather than emptying it.
+  const loadUserGroupDetails = useCallback(async () => {
+    const memberOf = user.memberOf;
+    if (!memberOf || memberOf.length === 0) {
       setAllGroups([]);
       return;
     }
 
     try {
-      const response = await api.getAllGroups();
+      const response = await api.resolveGroups(memberOf);
       if (response.success && response.groups) {
         setAllGroups(response.groups);
       }
     } catch {
-      console.error('Failed to load groups');
+      console.error('Failed to resolve group details');
     }
-  }, [canSearch]);
+  }, [user.memberOf]);
 
   const loadUserGroups = useCallback(() => {
     if (!user.memberOf) {
@@ -95,8 +96,8 @@ export function GroupMembership({ user, onUpdate }: GroupMembershipProps) {
   }, [user.memberOf, allGroups]);
 
   useEffect(() => {
-    loadAllGroups();
-  }, [loadAllGroups]);
+    loadUserGroupDetails();
+  }, [loadUserGroupDetails]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -110,10 +110,12 @@ class ApiService {
     return response.data;
   }
 
-  async getAllGroups(baseDN?: string): Promise<GroupsResponse> {
-    const params = baseDN ? `?baseDN=${encodeURIComponent(baseDN)}` : '';
-    const response = await this.client.get<GroupsResponse>(
-      `/api/v1/groups${params}`
+  // Resolves a known set of group DNs to full group records. Used instead of listing
+  // every group in the directory just to look up names and descriptions.
+  async resolveGroups(dns: string[]): Promise<GroupsResponse> {
+    const response = await this.client.post<GroupsResponse>(
+      '/api/v1/groups/resolve',
+      { dns }
     );
     return response.data;
   }


### PR DESCRIPTION
This feature changes how groups are loaded during initial request.
Previously, when logging in, service would load ALL of AD groups which could resulted in errors in particularly big AD.
This PR eliminates GetAllGroups endpoint and requires a query. 