### PR TITLE
feat: leadership observability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,17 @@ AD_MAX_SEARCH_RESULTS=200
 # If unset, every authenticated user may search. Nested group membership is resolved.
 # AD_SEARCH_ALLOWED_GROUPS=Helpdesk;CN=Directory Admins,OU=Groups,DC=example,DC=com
 
+# Optional: Comma-separated CN suffixes marking a group whose members lead it.
+# Unset by default, which disables lead detection entirely. Set it to opt in.
+# A user in "engineering-lead" or "engineering-pm" is then a lead of "engineering-*":
+# they can search their own subordinates but cannot browse the rest of the directory.
+# Scoping also requires AD_SEARCH_ALLOWED_GROUPS to be set (an empty allow-list leaves
+# every authenticated user unrestricted).
+# AD_LEAD_GROUP_SUFFIXES=-lead,-pm
+
+# Optional: String that replaces the matched suffix in the derived identifier.
+# AD_LEAD_GROUP_WILDCARD=-*
+
 # TLS/HTTPS Configuration for the web server
 # Set TLS_ENABLED=false to run HTTP instead of HTTPS
 TLS_ENABLED=true

--- a/README.md
+++ b/README.md
@@ -238,6 +238,144 @@ defaulting to direct only. Inherited memberships render with a disabled checkbox
 live on the parent group, so removing the user from the nested group would have no
 effect — the parent membership has to be changed instead.
 
+#### Group Membership and Leadership Roles
+
+Returns every group a user belongs to, together with the groups in which they hold a
+lead or PM role. Defaults to the calling user; passing a username looks up someone else
+and is gated like the other browsing endpoints.
+
+```bash
+curl -k https://localhost:8080/api/v1/groups/membership \
+  -H "X-Session-ID: your-session-id"
+
+curl -k https://localhost:8080/api/v1/groups/membership/jdoe \
+  -H "X-Session-ID: your-session-id"
+```
+
+A group whose CN ends in one of `AD_LEAD_GROUP_SUFFIXES` marks its members as leads of
+the corresponding base group. The suffix is replaced by `AD_LEAD_GROUP_WILDCARD` to form
+the identifier, so with `AD_LEAD_GROUP_SUFFIXES=-lead,-pm` both `engineering-lead` and
+`engineering-pm` collapse to the single entry `CN=engineering-*`:
+
+```json
+{
+  "success": true,
+  "group_details": [
+    {
+      "dn": "CN=engineering-lead,OU=Groups,DC=example,DC=com",
+      "cn": "engineering-lead",
+      "sAMAccountName": "engineering-lead"
+    },
+    {
+      "dn": "CN=Employees,OU=Groups,DC=example,DC=com",
+      "cn": "Employees",
+      "sAMAccountName": "Employees"
+    }
+  ],
+  "lead_group_membership": ["CN=engineering-*"]
+}
+```
+
+`group_details` holds every membership, including groups that carry no role; only the
+role-bearing ones appear in `lead_group_membership`. Matching is case-insensitive and
+considers the CN only, so an OU or DC component that happens to end in `-lead` is
+ignored. Malformed membership DNs are skipped rather than failing the request, and a
+directory lookup that fails still returns the derived roles with `group_details` empty,
+since the roles are read from the DNs alone.
+
+Holding a role grants **scoped** access to the browsing endpoints: a lead can see their
+own subordinates without being able to browse the rest of the directory. The identifiers
+also appear on `/api/v1/session` as `lead_group_membership` so the UI can label the scope.
+
+#### Lead Scoping
+
+**Lead detection is off unless you opt in.** `AD_LEAD_GROUP_SUFFIXES` is unset by
+default, so no group confers a role and nothing in this section applies — a directory
+that already uses `-lead` naming does not silently acquire leads on upgrade. Two
+variables must both be set for scoping to take effect:
+
+```bash
+AD_LEAD_GROUP_SUFFIXES=-lead,-pm                      # enables lead detection
+AD_SEARCH_ALLOWED_GROUPS=Helpdesk                     # enables access restriction
+```
+
+`AD_LEAD_GROUP_SUFFIXES` alone derives roles (reported on `/api/v1/session` and
+`/api/v1/groups/membership`, and used by the Team tab) but restricts nothing, because an
+empty `AD_SEARCH_ALLOWED_GROUPS` still leaves every authenticated user unrestricted. With
+both set, every authenticated user falls into one of three levels:
+
+| Level | Who | Sees |
+| --- | --- | --- |
+| Unrestricted | Members of `AD_SEARCH_ALLOWED_GROUPS` | The whole configured base DN |
+| Scoped | Leads and PMs (by CN suffix) | Only the groups they lead and those groups' members |
+| Denied | Everyone else | Nothing; browsing endpoints return 403 |
+
+The allow-list takes precedence, so an admin who also leads a team keeps unrestricted
+access rather than being narrowed to it. With lead detection off, a member of a `-lead`
+group is simply denied like any other user rather than getting scoped access.
+
+A lead of `CN=engineering-*` is scoped to every group whose CN begins with
+`engineering` — `engineering`, `engineering-devs`, `engineering-qa` — and to the users
+who are members of them. Enforcement is server-side, applied as an LDAP filter ANDed onto
+each search:
+
+- `/api/v1/search` returns only users who are members of an in-scope group.
+- `/api/v1/groups` lists only in-scope groups.
+- `/api/v1/groups/{name}` returns `404` for an out-of-scope group, so the response does
+  not reveal that it exists.
+- `/api/v1/users/{username}` and `/api/v1/groups/membership/{username}` return `404`
+  unless the target shares an in-scope group with the caller.
+- When a scoped lead views a subordinate, out-of-scope memberships are withheld, so they
+  cannot learn which other teams that person belongs to.
+
+The scope is ANDed on last, and a scoped request is forced back to the configured base
+DN, so neither a custom `baseDN` nor a raw `filter` can widen it. A lead whose wildcard
+matches no groups is denied rather than falling through to an unscoped search.
+
+In the web UI, leads get a **Team** sidebar tab listing everyone in the groups they lead,
+grouped by group with a client-side filter over names, usernames and emails. The tab is
+hidden for users who lead nothing, and the page skips the request entirely for them. It
+is backed by [`/api/v1/team`](#team).
+
+#### Team
+
+Returns the groups the caller leads, each with the users in it. This backs the **Team**
+tab in the web UI, which shows a lead everyone in their groups without exposing the rest
+of the directory.
+
+```bash
+curl -k https://localhost:8080/api/v1/team \
+  -H "X-Session-ID: your-session-id"
+```
+
+```json
+{
+  "success": true,
+  "memberCount": 2,
+  "lead_group_membership": ["CN=engineering-*"],
+  "groups": [
+    {
+      "group": {
+        "dn": "CN=engineering,OU=Groups,DC=example,DC=com",
+        "cn": "engineering",
+        "sAMAccountName": "engineering"
+      },
+      "members": [
+        { "dn": "CN=Ann Lee,OU=Users,DC=example,DC=com", "cn": "Ann Lee",
+          "sAMAccountName": "alee", "mail": "alee@example.com" }
+      ]
+    }
+  ]
+}
+```
+
+The scope is derived from the session, so there is nothing to pass in and no way to ask
+about someone else's team. `memberCount` counts distinct users, so a person in two of the
+lead's groups is counted once. Nested member groups are omitted — the view lists people,
+not structure — and a group whose members cannot be read is listed empty rather than
+dropping the whole response. A user who leads nothing gets an empty team rather than an
+error, so the endpoint is safe to call for any authenticated user.
+
 #### Add User to Group
 ```bash
 curl -k -X POST https://localhost:8080/api/v1/groups/add-member \
@@ -378,6 +516,8 @@ Response:
 | AD_EXCLUDED_OBJECTS | Semicolon-separated list of DN path fragments (OUs, CN containers) to exclude from results | |
 | AD_EXCLUDED_GROUPS | Semicolon-separated list of group CNs or DNs to exclude from results | |
 | AD_SEARCH_ALLOWED_GROUPS | Semicolon-separated group CNs or DNs allowed to use `/api/v1/search`; empty allows all authenticated users | |
+| AD_LEAD_GROUP_SUFFIXES | Comma-separated CN suffixes marking a lead/PM group (e.g. `-lead,-pm`); members get search scoped to those groups. **Empty disables lead detection entirely** | |
+| AD_LEAD_GROUP_WILDCARD | Replaces the matched suffix in the derived base-group identifier | -* |
 | TLS_ENABLED | Enable HTTPS | true |
 | TLS_CERT_FILE | Path to TLS certificate | certs/server.crt |
 | TLS_KEY_FILE | Path to TLS private key | certs/server.key |
@@ -413,6 +553,10 @@ This gates `/api/v1/search`, `/api/v1/groups` (group search) and
 `/api/v1/groups/{groupName}` (group inspection) — the endpoints that expose directory
 contents beyond the caller's own record. `/api/v1/groups/resolve` is deliberately not
 gated: it is bounded by the DNs the caller supplies.
+
+Setting this list also activates [lead scoping](#lead-scoping): users outside it who lead
+a `-lead` or `-pm` group keep access to their own subordinates instead of being denied
+outright, while remaining unable to browse the rest of the directory.
 
 Group CN and DN matching is case-insensitive. Use a full DN when groups with the same CN exist in multiple OUs.
 

--- a/README.md
+++ b/README.md
@@ -666,10 +666,28 @@ Key values (see [`charts/adel/values.yaml`](charts/adel/values.yaml) for the ful
 | `config.ad.server` / `config.ad.baseDN` | Required AD connection settings | `""` |
 | `tls.enabled` / `tls.secretName` | Terminate TLS in the Go server using a `kubernetes.io/tls` Secret | `false` |
 | `config.ad.caCertSecretName` | Secret containing a CA cert for LDAPS, mounted at `/certs/ca` | `""` |
+| `config.ad.maxSearchResults` | Cap on entries returned by any single LDAP search | `"200"` |
+| `config.ad.searchAllowedGroups` | Groups allowed to browse the directory; empty allows everyone | `""` |
+| `config.ad.leadGroupSuffixes` | CN suffixes enabling [lead scoping](#lead-scoping); empty disables it | `""` |
+| `config.ad.leadGroupWildcard` | Replaces the matched suffix in the derived identifier | `"-*"` |
 | `ingress.enabled` | Expose via Ingress | `false` |
 | `autoscaling.enabled` | Enable HPA | `false` |
 
 In most setups, leave `tls.enabled=false` and terminate TLS at the Ingress instead.
+
+To restrict leads and PMs to their own teams, set both scoping values — suffixes alone
+derive roles without limiting what anyone can see:
+
+```bash
+helm install adel adel/adel \
+  --set config.ad.server=dc1.example.com \
+  --set config.ad.baseDN="dc=example,dc=com" \
+  --set config.ad.searchAllowedGroups="Helpdesk" \
+  --set config.ad.leadGroupSuffixes="-lead\,-pm"
+```
+
+The comma in `leadGroupSuffixes` must be escaped on the `--set` command line, since Helm
+otherwise treats it as a list separator. In a values file it needs no escaping.
 
 ## Security Notes
 

--- a/charts/adel/templates/configmap.yaml
+++ b/charts/adel/templates/configmap.yaml
@@ -22,7 +22,10 @@ data:
   AD_SEARCH_BASE_DN: {{ .Values.config.ad.searchBaseDN | quote }}
   AD_EXCLUDED_OBJECTS: {{ .Values.config.ad.excludedObjects | quote }}
   AD_EXCLUDED_GROUPS: {{ .Values.config.ad.excludedGroups | quote }}
+  AD_MAX_SEARCH_RESULTS: {{ .Values.config.ad.maxSearchResults | quote }}
   AD_SEARCH_ALLOWED_GROUPS: {{ .Values.config.ad.searchAllowedGroups | quote }}
+  AD_LEAD_GROUP_SUFFIXES: {{ .Values.config.ad.leadGroupSuffixes | quote }}
+  AD_LEAD_GROUP_WILDCARD: {{ .Values.config.ad.leadGroupWildcard | quote }}
   {{- if .Values.config.ad.caCertSecretName }}
   AD_CA_CERT_PATH: "/certs/ca/{{ .Values.config.ad.caCertSecretKey }}"
   {{- end }}

--- a/charts/adel/values.yaml
+++ b/charts/adel/values.yaml
@@ -104,8 +104,20 @@ config:
     searchBaseDN: ""
     excludedObjects: ""
     excludedGroups: ""
+    # Maximum entries any single LDAP search may return (applied as the LDAP size limit).
+    maxSearchResults: "200"
     # Semicolon-separated group CNs or DNs. Empty allows every authenticated user to search.
     searchAllowedGroups: ""
+    # Lead/PM scoping. Comma-separated CN suffixes marking a group whose members lead it,
+    # e.g. "-lead,-pm". Empty (the default) disables lead detection entirely.
+    #
+    # Restricting leads to their own teams needs BOTH this and searchAllowedGroups set:
+    # with searchAllowedGroups empty every authenticated user stays unrestricted, so
+    # suffixes alone derive roles (session, Team tab) without limiting what anyone sees.
+    leadGroupSuffixes: ""
+    # Replaces the matched suffix in the derived identifier: "engineering-lead" becomes
+    # "engineering-*". Only consulted when leadGroupSuffixes is set.
+    leadGroupWildcard: "-*"
     # Name of a Secret key holding the CA cert PEM, mounted at /certs/ca/ca.crt when set.
     caCertSecretName: ""
     caCertSecretKey: "ca.crt"

--- a/config/config.go
+++ b/config/config.go
@@ -52,6 +52,18 @@ type ADConfig struct {
 	// SearchAllowedGroups is a list of group CNs or DNs whose members may use the search endpoint.
 	// If empty, search is available to every authenticated user.
 	SearchAllowedGroups []string
+	// LeadGroupSuffixes are the CN suffixes marking a role-bearing group, e.g. "-lead"
+	// and "-pm". A user in such a group is a lead/PM of the base group named by the CN
+	// with the suffix replaced by LeadGroupWildcard.
+	//
+	// Empty by default: lead detection is opt-in and stays completely inert until
+	// AD_LEAD_GROUP_SUFFIXES is set, so a directory that happens to use "-lead" naming
+	// does not silently acquire leads.
+	LeadGroupSuffixes []string
+	// LeadGroupWildcard replaces a matched suffix when deriving the base-group
+	// identifier: "engineering-lead" becomes "engineering-*". Only consulted when
+	// LeadGroupSuffixes is non-empty.
+	LeadGroupWildcard string
 	// Optional: Path to CA certificate for LDAPS
 	CACertPath string
 }
@@ -103,6 +115,8 @@ func Load() (*Config, error) {
 			MaxSearchResults:    getIntEnv("AD_MAX_SEARCH_RESULTS", 200),
 			ExcludedGroups:      getDNSliceEnv("AD_EXCLUDED_GROUPS", nil),
 			SearchAllowedGroups: getDNSliceEnv("AD_SEARCH_ALLOWED_GROUPS", nil),
+			LeadGroupSuffixes:   getSliceEnv("AD_LEAD_GROUP_SUFFIXES", nil),
+			LeadGroupWildcard:   getEnv("AD_LEAD_GROUP_WILDCARD", "-*"),
 			CACertPath:          getEnv("AD_CA_CERT_PATH", ""),
 		},
 		TLS: TLSConfig{
@@ -150,14 +164,52 @@ func (c *ADConfig) GetSearchBaseDN() string {
 	return c.BaseDN
 }
 
-// IsSearchAllowedFor reports whether a user holding the given group DNs may use the
-// search endpoint. Allowed groups may be configured as a full DN or a bare group CN.
-// An empty allow-list preserves the default of allowing every authenticated user.
-func (c *ADConfig) IsSearchAllowedFor(memberOf []string) bool {
+// SearchAccess describes how much of the directory a user may see.
+type SearchAccess int
+
+const (
+	// SearchDenied means the user may not use the browsing endpoints at all.
+	SearchDenied SearchAccess = iota
+	// SearchScoped means the user may search, but only within the groups they lead.
+	// Callers must apply LeadScopeFilter to every search they run for such a user.
+	SearchScoped
+	// SearchUnrestricted means the user may search the whole configured base DN.
+	SearchUnrestricted
+)
+
+// AccessFor reports how much of the directory a user holding the given group DNs may
+// see. The allow-list grants unrestricted access and takes precedence, so an admin who
+// also happens to lead a team is not accidentally narrowed to it. Otherwise a lead or
+// PM gets access scoped to the groups they lead, and everyone else is denied.
+//
+// An empty allow-list preserves the historical default of unrestricted access for every
+// authenticated user, so enabling lead scoping requires setting AD_SEARCH_ALLOWED_GROUPS.
+func (c *ADConfig) AccessFor(memberOf []string) SearchAccess {
 	if len(c.SearchAllowedGroups) == 0 {
-		return true
+		return SearchUnrestricted
 	}
 
+	if c.isAllowListed(memberOf) {
+		return SearchUnrestricted
+	}
+
+	if c.IsLeadFor(memberOf) {
+		return SearchScoped
+	}
+
+	return SearchDenied
+}
+
+// IsSearchAllowedFor reports whether a user may use the search endpoint in any capacity.
+// It does not distinguish scoped from unrestricted access: callers that run a directory
+// search must consult AccessFor and apply LeadScopeFilter when the result is SearchScoped.
+func (c *ADConfig) IsSearchAllowedFor(memberOf []string) bool {
+	return c.AccessFor(memberOf) != SearchDenied
+}
+
+// isAllowListed reports whether any of the user's groups appears in SearchAllowedGroups,
+// matched either as a full DN or as a bare CN.
+func (c *ADConfig) isAllowListed(memberOf []string) bool {
 	for _, groupDN := range memberOf {
 		for _, allowedGroup := range c.SearchAllowedGroups {
 			if strings.EqualFold(groupDN, allowedGroup) {
@@ -165,23 +217,166 @@ func (c *ADConfig) IsSearchAllowedFor(memberOf []string) bool {
 			}
 		}
 
-		parsedDN, err := ldap.ParseDN(groupDN)
-		if err != nil || len(parsedDN.RDNs) == 0 {
+		cn, ok := GroupCN(groupDN)
+		if !ok {
 			continue
 		}
-		for _, attribute := range parsedDN.RDNs[0].Attributes {
-			if !strings.EqualFold(attribute.Type, "CN") {
-				continue
-			}
-			for _, allowedGroup := range c.SearchAllowedGroups {
-				if !strings.Contains(allowedGroup, "=") && strings.EqualFold(attribute.Value, allowedGroup) {
-					return true
-				}
+		for _, allowedGroup := range c.SearchAllowedGroups {
+			if !strings.Contains(allowedGroup, "=") && strings.EqualFold(cn, allowedGroup) {
+				return true
 			}
 		}
 	}
 
 	return false
+}
+
+// GroupCN extracts the CN value from a group DN. Only the leftmost RDN is considered,
+// so OU and DC components never take part in CN matching. The second return value is
+// false when the DN is malformed or carries no CN, letting callers skip it safely.
+func GroupCN(groupDN string) (string, bool) {
+	parsedDN, err := ldap.ParseDN(groupDN)
+	if err != nil || len(parsedDN.RDNs) == 0 {
+		return "", false
+	}
+	for _, attribute := range parsedDN.RDNs[0].Attributes {
+		if strings.EqualFold(attribute.Type, "CN") {
+			return attribute.Value, true
+		}
+	}
+	return "", false
+}
+
+// LeadBasesFor returns the bare base-group names the user leads, e.g. "engineering" for
+// membership of "engineering-lead" or "engineering-pm". These are the raw names behind
+// the wildcard identifiers, and are what the scope filters match on.
+//
+// Matching is case-insensitive and confined to the CN. Groups without a configured
+// suffix, and DNs that cannot be parsed, are skipped — they remain ordinary memberships.
+// The result is de-duplicated and returned in first-seen order for stable output.
+func (c *ADConfig) LeadBasesFor(memberOf []string) []string {
+	if len(c.LeadGroupSuffixes) == 0 {
+		return nil
+	}
+
+	var bases []string
+	seen := make(map[string]struct{}, len(memberOf))
+
+	for _, groupDN := range memberOf {
+		cn, ok := GroupCN(groupDN)
+		if !ok {
+			continue
+		}
+
+		for _, suffix := range c.LeadGroupSuffixes {
+			if suffix == "" || !strings.HasSuffix(strings.ToLower(cn), strings.ToLower(suffix)) {
+				continue
+			}
+			// A CN that is nothing but the suffix has no base group to name.
+			base := cn[:len(cn)-len(suffix)]
+			if base == "" {
+				break
+			}
+
+			key := strings.ToLower(base)
+			if _, dup := seen[key]; !dup {
+				seen[key] = struct{}{}
+				bases = append(bases, base)
+			}
+			// Stop at the first matching suffix: suffixes are alternatives, and a CN
+			// ending in two of them would otherwise yield two entries.
+			break
+		}
+	}
+
+	return bases
+}
+
+// LeadGroupsFor derives the wildcard base-group identifiers for the groups in which the
+// user holds a lead or PM role, so both "engineering-lead" and "engineering-pm" collapse
+// to the single identifier "CN=engineering-*". These are display identifiers reported to
+// the UI; enforcement uses LeadScopeFilter, which is built from the same bases.
+func (c *ADConfig) LeadGroupsFor(memberOf []string) []string {
+	bases := c.LeadBasesFor(memberOf)
+	if len(bases) == 0 {
+		return nil
+	}
+
+	identifiers := make([]string, 0, len(bases))
+	for _, base := range bases {
+		identifiers = append(identifiers, "CN="+base+c.LeadGroupWildcard)
+	}
+	return identifiers
+}
+
+// IsLeadFor reports whether the user holds a lead or PM role in at least one group.
+func (c *ADConfig) IsLeadFor(memberOf []string) bool {
+	return len(c.LeadBasesFor(memberOf)) > 0
+}
+
+// LeadGroupCNFilter builds an LDAP filter matching the groups a lead may see: every
+// group whose CN starts with one of their base names. This is the wildcard rendered as
+// a filter, so "engineering-*" matches "engineering", "engineering-devs" and so on.
+//
+// Returns "" when the user leads nothing, which callers must treat as "match nothing"
+// rather than "match everything".
+func (c *ADConfig) LeadGroupCNFilter(memberOf []string) string {
+	bases := c.LeadBasesFor(memberOf)
+	if len(bases) == 0 {
+		return ""
+	}
+
+	var clauses strings.Builder
+	for _, base := range bases {
+		// The base is directory data, so it is escaped; the trailing * stays literal so
+		// it keeps its wildcard meaning.
+		clauses.WriteString("(cn=" + ldap.EscapeFilter(base) + "*)")
+	}
+
+	if len(bases) == 1 {
+		return clauses.String()
+	}
+	return "(|" + clauses.String() + ")"
+}
+
+// IsGroupInLeadScope reports whether a group CN falls within the caller's lead scope,
+// i.e. whether it starts with one of their base names. It mirrors LeadGroupCNFilter so
+// the in-process check and the LDAP-side filter agree on what "engineering-*" covers.
+//
+// A user who leads nothing has an empty scope and matches no group.
+func (c *ADConfig) IsGroupInLeadScope(memberOf []string, groupCN string) bool {
+	for _, base := range c.LeadBasesFor(memberOf) {
+		if strings.HasPrefix(strings.ToLower(groupCN), strings.ToLower(base)) {
+			return true
+		}
+	}
+	return false
+}
+
+// LeadScopeFilter builds an LDAP filter matching the users a lead may see: members of
+// any group within their wildcard scope. groupDNs are the in-scope group DNs, resolved
+// by the caller via LeadGroupCNFilter, since membership must be tested against concrete
+// DNs rather than names.
+//
+// Returns "" when there are no in-scope groups, which callers must treat as
+// "match nothing" so an empty scope cannot silently widen into a full directory search.
+func LeadScopeFilter(groupDNs []string) string {
+	if len(groupDNs) == 0 {
+		return ""
+	}
+
+	var clauses strings.Builder
+	for _, dn := range groupDNs {
+		// matchingRuleInChain would also catch users nested through subgroups, but it is
+		// AD-specific; a direct memberOf test works on every directory and matches how
+		// the rest of the group endpoints resolve membership.
+		clauses.WriteString("(memberOf=" + ldap.EscapeFilter(dn) + ")")
+	}
+
+	if len(groupDNs) == 1 {
+		return clauses.String()
+	}
+	return "(|" + clauses.String() + ")"
 }
 
 // GetLDAPURL returns the LDAP connection URL

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -273,7 +274,7 @@ func TestIsSearchAllowedFor(t *testing.T) {
 		},
 		{
 			name:          "matches group CN case-insensitively",
-			memberOf:      []string{"CN=Helpdesk,OU=Groups,DC=example,DC=com"},
+			memberOf:      []string{dnHelpdesk},
 			allowedGroups: []string{"helpdesk"},
 			want:          true,
 		},
@@ -291,13 +292,13 @@ func TestIsSearchAllowedFor(t *testing.T) {
 		},
 		{
 			name:          "matches a group reached through nesting",
-			memberOf:      []string{"CN=Helpdesk-Tier1,OU=Groups,DC=example,DC=com", "CN=Helpdesk,OU=Groups,DC=example,DC=com"},
+			memberOf:      []string{"CN=Helpdesk-Tier1,OU=Groups,DC=example,DC=com", dnHelpdesk},
 			allowedGroups: []string{"Helpdesk"},
 			want:          true,
 		},
 		{
 			name:          "rejects users outside allowed groups",
-			memberOf:      []string{"CN=Employees,OU=Groups,DC=example,DC=com"},
+			memberOf:      []string{dnEmployees},
 			allowedGroups: []string{"Helpdesk", "Directory Admins"},
 			want:          false,
 		},
@@ -316,5 +317,333 @@ func TestIsSearchAllowedFor(t *testing.T) {
 					tt.memberOf, tt.allowedGroups, got, tt.want)
 			}
 		})
+	}
+}
+
+// Shared DN fixtures, so the expected derivations read against a single spelling.
+const (
+	dnHelpdesk        = "CN=Helpdesk,OU=Groups,DC=example,DC=com"
+	dnEngineeringLead = "CN=engineering-lead,OU=Groups,DC=example,DC=com"
+	dnEmployees       = "CN=Employees,OU=Groups,DC=example,DC=com"
+	wildcardEngineer  = "CN=engineering-*"
+)
+
+// enabledLeadConfig is a config with lead detection switched on, as an operator would
+// after setting AD_LEAD_GROUP_SUFFIXES. Lead detection is off unless configured, so
+// tests must opt in explicitly rather than relying on a default.
+func enabledLeadConfig() *ADConfig {
+	return &ADConfig{
+		LeadGroupSuffixes: []string{"-lead", "-pm"},
+		LeadGroupWildcard: "-*",
+	}
+}
+
+func TestLeadGroupsFor(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *ADConfig
+		memberOf []string
+		want     []string
+	}{
+		{
+			name:     "derives wildcard identifier from a lead group",
+			cfg:      enabledLeadConfig(),
+			memberOf: []string{dnEngineeringLead},
+			want:     []string{wildcardEngineer},
+		},
+		{
+			name:     "derives wildcard identifier from a pm group",
+			cfg:      enabledLeadConfig(),
+			memberOf: []string{"CN=engineering-pm,OU=Groups,DC=example,DC=com"},
+			want:     []string{wildcardEngineer},
+		},
+		{
+			name: "collapses lead and pm of the same base group",
+			cfg:  enabledLeadConfig(),
+			memberOf: []string{
+				dnEngineeringLead,
+				"CN=engineering-pm,OU=Other,DC=example,DC=com",
+			},
+			want: []string{wildcardEngineer},
+		},
+		{
+			name: "matches suffixes case-insensitively",
+			cfg:  enabledLeadConfig(),
+			memberOf: []string{
+				"CN=Engineering-LEAD,OU=Groups,DC=example,DC=com",
+				"CN=Support-Pm,OU=Groups,DC=example,DC=com",
+			},
+			want: []string{"CN=Engineering-*", "CN=Support-*"},
+		},
+		{
+			name:     "excludes groups without a role suffix",
+			cfg:      enabledLeadConfig(),
+			memberOf: []string{dnEmployees},
+			want:     nil,
+		},
+		{
+			name: "ignores suffixes appearing only in OU or DC components",
+			cfg:  enabledLeadConfig(),
+			memberOf: []string{
+				"CN=Employees,OU=engineering-lead,DC=example,DC=com",
+				"CN=Employees,OU=Groups,DC=corp-pm,DC=com",
+			},
+			want: nil,
+		},
+		{
+			name: "skips malformed DNs and keeps processing the rest",
+			cfg:  enabledLeadConfig(),
+			memberOf: []string{
+				"not a dn",
+				"",
+				dnEngineeringLead,
+			},
+			want: []string{wildcardEngineer},
+		},
+		{
+			name:     "keeps a CN that is only the suffix out of the results",
+			cfg:      enabledLeadConfig(),
+			memberOf: []string{"CN=-lead,OU=Groups,DC=example,DC=com"},
+			want:     nil,
+		},
+		{
+			name:     "honours custom suffixes",
+			cfg:      &ADConfig{LeadGroupSuffixes: []string{"-owner"}, LeadGroupWildcard: "-*"},
+			memberOf: []string{"CN=payments-owner,OU=Groups,DC=example,DC=com", "CN=payments-lead,OU=Groups,DC=example,DC=com"},
+			want:     []string{"CN=payments-*"},
+		},
+		{
+			name:     "honours a custom wildcard",
+			cfg:      &ADConfig{LeadGroupSuffixes: []string{"-lead"}, LeadGroupWildcard: "-all"},
+			memberOf: []string{dnEngineeringLead},
+			want:     []string{"CN=engineering-all"},
+		},
+		{
+			name:     "disabled when no suffixes are configured",
+			cfg:      &ADConfig{LeadGroupWildcard: "-*"},
+			memberOf: []string{dnEngineeringLead},
+			want:     nil,
+		},
+		{
+			name: "preserves an escaped comma in the CN",
+			cfg:  enabledLeadConfig(),
+			memberOf: []string{
+				`CN=Support\, Tier 2-lead,OU=Groups,DC=example,DC=com`,
+			},
+			want: []string{"CN=Support, Tier 2-*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.cfg.LeadGroupsFor(tt.memberOf)
+			if len(got) != len(tt.want) {
+				t.Fatalf("LeadGroupsFor(%v) = %v, want %v", tt.memberOf, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("LeadGroupsFor(%v)[%d] = %q, want %q", tt.memberOf, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// TestLeadDetectionDisabledByDefault pins the opt-in contract: without
+// AD_LEAD_GROUP_SUFFIXES the feature is completely inert, so a directory that happens to
+// use "-lead" naming does not silently acquire leads with scoped search access.
+func TestLeadDetectionDisabledByDefault(t *testing.T) {
+	os.Setenv("AD_SERVER", "test-ad.example.com")
+	os.Setenv("AD_BASE_DN", "dc=test,dc=com")
+	os.Setenv("AD_SEARCH_ALLOWED_GROUPS", "Helpdesk")
+	defer os.Unsetenv("AD_SERVER")
+	defer os.Unsetenv("AD_BASE_DN")
+	defer os.Unsetenv("AD_SEARCH_ALLOWED_GROUPS")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(cfg.AD.LeadGroupSuffixes) != 0 {
+		t.Errorf("LeadGroupSuffixes = %v, want empty by default", cfg.AD.LeadGroupSuffixes)
+	}
+
+	lead := []string{dnEngineeringLead}
+	if cfg.AD.IsLeadFor(lead) {
+		t.Error("membership of a -lead group must not confer a role when the feature is off")
+	}
+	if got := cfg.AD.LeadGroupsFor(lead); len(got) != 0 {
+		t.Errorf("LeadGroupsFor() = %v, want none when the feature is off", got)
+	}
+	if got := cfg.AD.LeadGroupCNFilter(lead); got != "" {
+		t.Errorf("LeadGroupCNFilter() = %q, want empty when the feature is off", got)
+	}
+	// With the allow-list set and lead detection off, a -lead member is simply denied
+	// rather than silently getting scoped access.
+	if got := cfg.AD.AccessFor(lead); got != SearchDenied {
+		t.Errorf("AccessFor() = %v, want SearchDenied when the feature is off", got)
+	}
+}
+
+// TestLeadDetectionEnabledByEnv confirms setting the env var turns the feature on.
+func TestLeadDetectionEnabledByEnv(t *testing.T) {
+	os.Setenv("AD_SERVER", "test-ad.example.com")
+	os.Setenv("AD_BASE_DN", "dc=test,dc=com")
+	os.Setenv("AD_LEAD_GROUP_SUFFIXES", "-lead,-pm")
+	defer os.Unsetenv("AD_SERVER")
+	defer os.Unsetenv("AD_BASE_DN")
+	defer os.Unsetenv("AD_LEAD_GROUP_SUFFIXES")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if !cfg.AD.IsLeadFor([]string{dnEngineeringLead}) {
+		t.Error("a -lead member should hold a role once the suffixes are configured")
+	}
+	if got := cfg.AD.LeadGroupsFor([]string{dnEngineeringLead}); len(got) != 1 || got[0] != wildcardEngineer {
+		t.Errorf("LeadGroupsFor() = %v, want [%s]", got, wildcardEngineer)
+	}
+}
+
+func TestAccessFor(t *testing.T) {
+	withAllowList := enabledLeadConfig()
+	withAllowList.SearchAllowedGroups = []string{"Helpdesk"}
+
+	tests := []struct {
+		name     string
+		cfg      *ADConfig
+		memberOf []string
+		want     SearchAccess
+	}{
+		{
+			name:     "empty allow-list leaves everyone unrestricted",
+			cfg:      enabledLeadConfig(),
+			memberOf: []string{dnEmployees},
+			want:     SearchUnrestricted,
+		},
+		{
+			name:     "allow-listed user is unrestricted",
+			cfg:      withAllowList,
+			memberOf: []string{dnHelpdesk},
+			want:     SearchUnrestricted,
+		},
+		{
+			name:     "lead is scoped rather than unrestricted",
+			cfg:      withAllowList,
+			memberOf: []string{dnEngineeringLead},
+			want:     SearchScoped,
+		},
+		{
+			name:     "pm is scoped",
+			cfg:      withAllowList,
+			memberOf: []string{"CN=engineering-pm,OU=Groups,DC=example,DC=com"},
+			want:     SearchScoped,
+		},
+		{
+			name:     "allow-list wins over lead role",
+			cfg:      withAllowList,
+			memberOf: []string{dnEngineeringLead, dnHelpdesk},
+			want:     SearchUnrestricted,
+		},
+		{
+			name:     "plain member is denied",
+			cfg:      withAllowList,
+			memberOf: []string{dnEmployees},
+			want:     SearchDenied,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.cfg.AccessFor(tt.memberOf); got != tt.want {
+				t.Errorf("AccessFor(%v) = %v, want %v", tt.memberOf, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLeadGroupCNFilter(t *testing.T) {
+	cfg := enabledLeadConfig()
+
+	t.Run("matches the base name as a prefix wildcard", func(t *testing.T) {
+		got := cfg.LeadGroupCNFilter([]string{dnEngineeringLead})
+		want := "(cn=engineering*)"
+		if got != want {
+			t.Errorf("LeadGroupCNFilter() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ORs multiple bases", func(t *testing.T) {
+		got := cfg.LeadGroupCNFilter([]string{
+			dnEngineeringLead,
+			"CN=support-pm,OU=Groups,DC=example,DC=com",
+		})
+		want := "(|(cn=engineering*)(cn=support*))"
+		if got != want {
+			t.Errorf("LeadGroupCNFilter() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty for a non-lead so callers match nothing", func(t *testing.T) {
+		if got := cfg.LeadGroupCNFilter([]string{dnEmployees}); got != "" {
+			t.Errorf("LeadGroupCNFilter() = %q, want empty", got)
+		}
+	})
+
+	t.Run("escapes filter metacharacters in the base name", func(t *testing.T) {
+		got := cfg.LeadGroupCNFilter([]string{`CN=a)(b-lead,OU=Groups,DC=example,DC=com`})
+		if strings.Contains(got, "a)(b") {
+			t.Errorf("LeadGroupCNFilter() = %q, want the base name escaped", got)
+		}
+	})
+}
+
+func TestLeadScopeFilter(t *testing.T) {
+	t.Run("matches members of one group", func(t *testing.T) {
+		got := LeadScopeFilter([]string{"CN=engineering,OU=Groups,DC=example,DC=com"})
+		want := "(memberOf=CN=engineering,OU=Groups,DC=example,DC=com)"
+		if got != want {
+			t.Errorf("LeadScopeFilter() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("ORs multiple groups", func(t *testing.T) {
+		got := LeadScopeFilter([]string{"CN=a,DC=x", "CN=b,DC=x"})
+		want := "(|(memberOf=CN=a,DC=x)(memberOf=CN=b,DC=x))"
+		if got != want {
+			t.Errorf("LeadScopeFilter() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty scope yields empty filter, never a match-all", func(t *testing.T) {
+		if got := LeadScopeFilter(nil); got != "" {
+			t.Errorf("LeadScopeFilter(nil) = %q, want empty", got)
+		}
+	})
+}
+
+func TestIsGroupInLeadScope(t *testing.T) {
+	cfg := enabledLeadConfig()
+	lead := []string{dnEngineeringLead}
+
+	inScope := []string{"engineering", "engineering-devs", "Engineering-QA", "engineering-lead"}
+	for _, cn := range inScope {
+		if !cfg.IsGroupInLeadScope(lead, cn) {
+			t.Errorf("IsGroupInLeadScope(%q) = false, want true", cn)
+		}
+	}
+
+	outOfScope := []string{"finance", "finance-team", "eng", "core-engineering"}
+	for _, cn := range outOfScope {
+		if cfg.IsGroupInLeadScope(lead, cn) {
+			t.Errorf("IsGroupInLeadScope(%q) = true, want false", cn)
+		}
+	}
+
+	if cfg.IsGroupInLeadScope([]string{dnEmployees}, "engineering") {
+		t.Error("a non-lead should have an empty scope matching nothing")
 	}
 }

--- a/handlers/handler.go
+++ b/handlers/handler.go
@@ -28,6 +28,7 @@ const (
 	errMsgSearchNotPermitted = "Search is not permitted for this user"
 	errMsgQueryRequired      = "A query or filter is required; listing all groups is not supported"
 	logKeyUserDN             = "userDN"
+	logKeyUsername           = "username"
 
 	// objectClassGroup is the LDAP objectClass marking an entry as a group.
 	objectClassGroup = "group"
@@ -185,6 +186,21 @@ func (h *Handler) GetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// A scoped lead may only read their own subordinates. Without this the scoping on
+	// /search would be cosmetic: a lead could read any user by naming them directly.
+	// Reported as "not found" so the response does not confirm the user exists.
+	if h.config.AD.AccessFor(sess.MemberOf) == config.SearchScoped &&
+		!strings.EqualFold(username, sess.Username) &&
+		!h.sharesLeadScope(sess, user.MemberOf) {
+		slog.Warn("User lookup denied: target is outside the caller's lead scope",
+			logKeyUsername, sess.Username, "target", username)
+		writeJSON(w, http.StatusNotFound, models.UserResponse{
+			Success: false,
+			Error:   "User not found",
+		})
+		return
+	}
+
 	writeJSON(w, http.StatusOK, models.UserResponse{
 		Success: true,
 		User:    user,
@@ -262,6 +278,95 @@ func (h *Handler) EditUser(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// leadScopeGroups resolves the groups a scoped user is entitled to see: every group
+// whose CN matches one of their lead wildcards. It is the bridge between the derived
+// "engineering-*" identifiers and the concrete DNs that membership filters need.
+//
+// An empty result means the wildcards matched nothing, and callers must deny rather than
+// fall through to an unscoped search.
+func (h *Handler) leadScopeGroups(sess *session.Session) ([]*models.Group, error) {
+	cnFilter := h.config.AD.LeadGroupCNFilter(sess.MemberOf)
+	if cnFilter == "" {
+		return nil, nil
+	}
+
+	searchReq := ldap.NewSearchRequest(
+		h.config.AD.GetSearchBaseDN(),
+		ldap.ScopeWholeSubtree,
+		ldap.NeverDerefAliases,
+		h.config.AD.MaxSearchResults, 0, false,
+		fmt.Sprintf("(&%s%s)", h.config.AD.GroupFilter, cnFilter),
+		groupAttributes,
+		nil,
+	)
+
+	sr, err := sess.Conn.Search(searchReq)
+	if err != nil {
+		return nil, err
+	}
+
+	return h.entriesToGroups(sr.Entries), nil
+}
+
+// leadScopeDNs returns the DNs of the groups a scoped user may see.
+func (h *Handler) leadScopeDNs(sess *session.Session) ([]string, error) {
+	groups, err := h.leadScopeGroups(sess)
+	if err != nil {
+		return nil, err
+	}
+
+	dns := make([]string, 0, len(groups))
+	for _, g := range groups {
+		dns = append(dns, g.DN)
+	}
+	return dns, nil
+}
+
+// sharesLeadScope reports whether any of the target's groups falls inside the caller's
+// lead scope, i.e. whether the target is one of the caller's subordinates.
+func (h *Handler) sharesLeadScope(sess *session.Session, targetMemberOf []string) bool {
+	for _, dn := range targetMemberOf {
+		cn, ok := config.GroupCN(dn)
+		if !ok {
+			continue
+		}
+		if h.config.AD.IsGroupInLeadScope(sess.MemberOf, cn) {
+			return true
+		}
+	}
+	return false
+}
+
+// filterToLeadScope keeps only the group DNs that fall inside the caller's lead scope,
+// so a scoped lead never learns which out-of-scope groups a subordinate belongs to.
+func (h *Handler) filterToLeadScope(sess *session.Session, memberOf []string) []string {
+	kept := make([]string, 0, len(memberOf))
+	for _, dn := range memberOf {
+		cn, ok := config.GroupCN(dn)
+		if !ok {
+			continue
+		}
+		if h.config.AD.IsGroupInLeadScope(sess.MemberOf, cn) {
+			kept = append(kept, dn)
+		}
+	}
+	return kept
+}
+
+// denyOutOfScope writes the standard refusal for a scoped user whose request falls
+// outside the groups they lead.
+func denyOutOfScope(w http.ResponseWriter, sess *session.Session, operation string) {
+	slog.Warn("Request denied: outside the caller's lead scope",
+		"operation", operation,
+		logKeyUsername, sess.Username,
+		logKeyUserDN, sess.UserDN,
+	)
+	writeJSON(w, http.StatusForbidden, models.APIResponse{
+		Success: false,
+		Error:   errMsgSearchNotPermitted,
+	})
+}
+
 // GetAllGroups retrieves all groups from AD
 func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 	sess := middleware.GetSessionFromContext(r.Context())
@@ -272,7 +377,8 @@ func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if !h.config.AD.IsSearchAllowedFor(sess.MemberOf) {
+	access := h.config.AD.AccessFor(sess.MemberOf)
+	if access == config.SearchDenied {
 		slog.Warn("Group listing denied: user is not a member of any allowed group",
 			"username", sess.Username,
 			logKeyUserDN, sess.UserDN,
@@ -284,6 +390,17 @@ func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 			Error:   errMsgSearchNotPermitted,
 		})
 		return
+	}
+
+	// A scoped lead may only see the groups within their wildcard, so their listing is
+	// confined to those CNs rather than the whole base DN.
+	scopeFilter := ""
+	if access == config.SearchScoped {
+		scopeFilter = h.config.AD.LeadGroupCNFilter(sess.MemberOf)
+		if scopeFilter == "" {
+			denyOutOfScope(w, sess, "GetAllGroups")
+			return
+		}
 	}
 
 	// Get optional baseDN from query params
@@ -319,6 +436,14 @@ func (h *Handler) GetAllGroups(w http.ResponseWriter, r *http.Request) {
 			"(&%s(|(cn=*%s*)(sAMAccountName=*%s*)))",
 			h.config.AD.GroupFilter, escaped, escaped,
 		)
+	}
+
+	// The scope is ANDed on last so it cannot be widened by the caller's own filter, and
+	// the base DN is forced back to the configured root so a custom baseDN cannot reach
+	// outside it either.
+	if scopeFilter != "" {
+		filter = fmt.Sprintf("(&%s%s)", filter, scopeFilter)
+		baseDN = h.config.AD.GetSearchBaseDN()
 	}
 
 	// Search for groups
@@ -363,7 +488,8 @@ func (h *Handler) GetGroup(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if !h.config.AD.IsSearchAllowedFor(sess.MemberOf) {
+	access := h.config.AD.AccessFor(sess.MemberOf)
+	if access == config.SearchDenied {
 		slog.Warn("Group inspection denied: user is not a member of any allowed group",
 			"username", sess.Username,
 			logKeyUserDN, sess.UserDN,
@@ -391,6 +517,20 @@ func (h *Handler) GetGroup(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusNotFound, models.GroupDetailResponse{
 			Success: false,
 			Error:   fmt.Sprintf("Group not found: %v", err),
+		})
+		return
+	}
+
+	// A scoped lead may only inspect groups inside their wildcard. The check runs on the
+	// resolved group so it cannot be sidestepped by naming the group differently (CN vs
+	// sAMAccountName), and reports "not found" rather than "forbidden" so the response
+	// does not confirm that an out-of-scope group exists.
+	if access == config.SearchScoped && !h.config.AD.IsGroupInLeadScope(sess.MemberOf, group.CN) {
+		slog.Warn("Group inspection denied: group is outside the caller's lead scope",
+			logKeyUsername, sess.Username, logKeyGroup, group.CN)
+		writeJSON(w, http.StatusNotFound, models.GroupDetailResponse{
+			Success: false,
+			Error:   "Group not found",
 		})
 		return
 	}
@@ -710,6 +850,181 @@ func countNonEmpty(values []string) int {
 	return n
 }
 
+// GroupMembership returns every group the given user belongs to, together with the
+// wildcard identifiers of the groups in which they hold a lead or PM role. Defaults to
+// the calling user when no username is supplied.
+//
+// Group details are best-effort: a directory lookup that fails leaves the details empty
+// but still returns the roles derived from the membership DNs, since role derivation
+// reads only the DNs and does not depend on the lookup succeeding.
+func (h *Handler) GroupMembership(w http.ResponseWriter, r *http.Request) {
+	sess := middleware.GetSessionFromContext(r.Context())
+	if sess == nil {
+		writeJSON(w, http.StatusUnauthorized, models.GroupMembershipResponse{
+			Success: false,
+			Error:   errMsgSessionNotFound,
+		})
+		return
+	}
+
+	// Looking up a user other than yourself exposes directory contents, so it is gated
+	// like the other browsing endpoints; your own memberships always remain readable.
+	username := strings.TrimSpace(mux.Vars(r)["username"])
+	memberOf := sess.MemberOf
+	isSelf := username == "" || strings.EqualFold(username, sess.Username)
+
+	access := h.config.AD.AccessFor(sess.MemberOf)
+	if !isSelf {
+		if access == config.SearchDenied {
+			writeJSON(w, http.StatusForbidden, models.GroupMembershipResponse{
+				Success: false,
+				Error:   errMsgSearchNotPermitted,
+			})
+			return
+		}
+
+		user, err := h.findUser(sess.Conn, username)
+		if err != nil {
+			logLDAPError("group membership lookup", err, map[string]string{logKeyUsername: username})
+			writeJSON(w, http.StatusNotFound, models.GroupMembershipResponse{
+				Success: false,
+				Error:   fmt.Sprintf("Failed to get user: %v", err),
+			})
+			return
+		}
+
+		// A scoped lead may only inspect their own subordinates: the target must share at
+		// least one in-scope group. Reported as "not found" so the response does not
+		// confirm that an out-of-scope user exists.
+		if access == config.SearchScoped && !h.sharesLeadScope(sess, user.MemberOf) {
+			slog.Warn("Group membership lookup denied: user is outside the caller's lead scope",
+				logKeyUsername, sess.Username, "target", username)
+			writeJSON(w, http.StatusNotFound, models.GroupMembershipResponse{
+				Success: false,
+				Error:   "User not found",
+			})
+			return
+		}
+
+		memberOf = user.MemberOf
+	}
+
+	// The roles reported are always the target's own, but a scoped lead sees only the
+	// portion of another user's memberships that falls inside their scope.
+	leadGroups := h.config.AD.LeadGroupsFor(memberOf)
+	if !isSelf && access == config.SearchScoped {
+		memberOf = h.filterToLeadScope(sess, memberOf)
+	}
+
+	groups := []*models.Group{}
+	if dns := normalizeDNs(memberOf, make(map[string]struct{}, len(memberOf)), maxResolveDNs); len(dns) > 0 {
+		resolved, err := h.resolveGroupDNs(sess.Conn, dns, groupAttributes)
+		if err != nil {
+			// Degrade rather than fail: the roles above are still valid without details.
+			slog.Warn("Failed to resolve group details, returning roles only",
+				"username", sess.Username, "error", err)
+		} else {
+			groups = resolved
+		}
+	}
+
+	writeJSON(w, http.StatusOK, models.GroupMembershipResponse{
+		Success:             true,
+		GroupDetails:        groups,
+		LeadGroupMembership: leadGroups,
+	})
+}
+
+// Team lists the groups the caller leads together with their members, so a lead can see
+// everyone reporting into their teams in one view.
+//
+// The scope is the caller's own lead wildcards, so this is safe for any authenticated
+// user: a non-lead simply has an empty scope and gets an empty team. Users with
+// unrestricted access are not leads by definition and also get an empty result, which
+// keeps the endpoint about leadership rather than doubling as a directory dump.
+func (h *Handler) Team(w http.ResponseWriter, r *http.Request) {
+	sess := middleware.GetSessionFromContext(r.Context())
+	if sess == nil {
+		writeJSON(w, http.StatusUnauthorized, models.TeamResponse{
+			Success: false,
+			Error:   errMsgSessionNotFound,
+		})
+		return
+	}
+
+	leadGroups := h.config.AD.LeadGroupsFor(sess.MemberOf)
+	if len(leadGroups) == 0 {
+		writeJSON(w, http.StatusOK, models.TeamResponse{
+			Success:             true,
+			Groups:              []*models.TeamGroup{},
+			LeadGroupMembership: []string{},
+		})
+		return
+	}
+
+	scopeGroups, err := h.leadScopeGroups(sess)
+	if err != nil {
+		slog.Error("Failed to resolve team scope",
+			logKeyUsername, sess.Username, "error", err)
+		writeJSON(w, http.StatusInternalServerError, models.TeamResponse{
+			Success: false,
+			Error:   "Failed to resolve team",
+		})
+		return
+	}
+
+	// Distinct members across all of the lead's groups, so someone in two teams is
+	// counted once even though they appear under each group they belong to.
+	distinct := make(map[string]struct{})
+	teams := make([]*models.TeamGroup, 0, len(scopeGroups))
+
+	for _, group := range scopeGroups {
+		if h.isExcludedGroup(group.CN, group.DN) {
+			continue
+		}
+
+		members, truncated, err := h.findGroupMembers(sess.Conn, group.DN)
+		if err != nil {
+			// One unreadable group must not blank the whole view, so it is listed with
+			// no members rather than dropped.
+			slog.Warn("Failed to list team group members",
+				logKeyUsername, sess.Username, logKeyGroup, group.CN, "error", err)
+			members = []*models.GroupMember{}
+		}
+
+		// Nested groups are structure, not people; the Team view lists users.
+		users := make([]*models.GroupMember, 0, len(members))
+		for _, m := range members {
+			if m.IsGroup {
+				continue
+			}
+			users = append(users, m)
+			distinct[strings.ToLower(m.DN)] = struct{}{}
+		}
+
+		sort.Slice(users, func(i, j int) bool {
+			return strings.ToLower(memberLabel(users[i])) < strings.ToLower(memberLabel(users[j]))
+		})
+
+		teams = append(teams, &models.TeamGroup{
+			Group:     group,
+			Members:   users,
+			Truncated: truncated,
+		})
+	}
+
+	sort.Slice(teams, func(i, j int) bool {
+		return strings.ToLower(teams[i].Group.CN) < strings.ToLower(teams[j].Group.CN)
+	})
+
+	writeJSON(w, http.StatusOK, models.TeamResponse{
+		Success:             true,
+		Groups:              teams,
+		MemberCount:         len(distinct),
+		LeadGroupMembership: leadGroups,
+	})
+}
+
 // AddUserToGroup adds a user to a group
 func (h *Handler) AddUserToGroup(w http.ResponseWriter, r *http.Request) {
 	sess := middleware.GetSessionFromContext(r.Context())
@@ -772,10 +1087,10 @@ func (h *Handler) AddUserToGroup(w http.ResponseWriter, r *http.Request) {
 	if err := sess.Conn.Modify(modifyReq); err != nil {
 		// Log detailed LDAP error information
 		logLDAPError("AddUserToGroup", err, map[string]string{
-			"username":   req.Username,
-			logKeyUserDN: userDN,
-			logKeyGroup:  req.GroupName,
-			"groupDN":    groupDN,
+			logKeyUsername: req.Username,
+			logKeyUserDN:   userDN,
+			logKeyGroup:    req.GroupName,
+			"groupDN":      groupDN,
 		})
 
 		// Check if user is already a member
@@ -878,10 +1193,10 @@ func (h *Handler) RemoveUserFromGroup(w http.ResponseWriter, r *http.Request) {
 	if err := sess.Conn.Modify(modifyReq); err != nil {
 		// Log detailed LDAP error information
 		logLDAPError("RemoveUserFromGroup", err, map[string]string{
-			"username":   req.Username,
-			logKeyUserDN: userDN,
-			logKeyGroup:  req.GroupName,
-			"groupDN":    groupDN,
+			logKeyUsername: req.Username,
+			logKeyUserDN:   userDN,
+			logKeyGroup:    req.GroupName,
+			"groupDN":      groupDN,
 		})
 
 		// Check if user is not a member
@@ -958,7 +1273,8 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
 		})
 		return
 	}
-	if !h.config.AD.IsSearchAllowedFor(sess.MemberOf) {
+	access := h.config.AD.AccessFor(sess.MemberOf)
+	if access == config.SearchDenied {
 		slog.Warn("Search denied: user is not a member of any allowed group",
 			"username", sess.Username,
 			logKeyUserDN, sess.UserDN,
@@ -970,6 +1286,34 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
 			Error:   errMsgSearchNotPermitted,
 		})
 		return
+	}
+
+	// A scoped lead sees only members of the groups they lead. The in-scope groups are
+	// resolved up front so the membership test runs against concrete DNs.
+	scopeFilter := ""
+	if access == config.SearchScoped {
+		scopeDNs, err := h.leadScopeDNs(sess)
+		if err != nil {
+			slog.Error("Failed to resolve lead scope, denying search",
+				logKeyUsername, sess.Username, "error", err)
+			writeJSON(w, http.StatusInternalServerError, models.SearchResponse{
+				Success: false,
+				Error:   "Failed to resolve search scope",
+			})
+			return
+		}
+		// No in-scope groups means nothing is visible. Falling through here would run an
+		// unscoped search, so this must deny.
+		scopeFilter = config.LeadScopeFilter(scopeDNs)
+		if scopeFilter == "" {
+			slog.Warn("Search denied: lead scope resolved to no groups",
+				logKeyUsername, sess.Username, logKeyUserDN, sess.UserDN)
+			writeJSON(w, http.StatusForbidden, models.SearchResponse{
+				Success: false,
+				Error:   errMsgSearchNotPermitted,
+			})
+			return
+		}
 	}
 
 	// Get parameters from query string (GET) or request body (POST)
@@ -1016,6 +1360,11 @@ func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
 		)
 	} else if filter == "" {
 		filter = h.config.AD.SearchFilter
+	}
+	// ANDed on last so neither a raw filter nor a custom baseDN can widen the scope.
+	if scopeFilter != "" {
+		filter = fmt.Sprintf("(&%s%s)", filter, scopeFilter)
+		baseDN = h.config.AD.GetSearchBaseDN()
 	}
 	if len(attributes) == 0 {
 		attributes = []string{"*"}

--- a/handlers/handler_test.go
+++ b/handlers/handler_test.go
@@ -23,6 +23,7 @@ import (
 // Fixture values shared by handler tests.
 const (
 	testUsername      = "testuser"
+	testEngLeadDN     = "CN=engineering-lead,OU=Groups,DC=example,DC=com"
 	testEmployeesDN   = "CN=Employees,OU=Groups,DC=example,DC=com"
 	testAdminsCN      = "Admins"
 	testMemberCN      = "Ann Lee"
@@ -319,6 +320,174 @@ func TestSearchForbiddenOutsideAllowedGroups(t *testing.T) {
 	}
 	if response.Success || response.Error == "" {
 		t.Errorf("response = %+v, want unsuccessful response with an error", response)
+	}
+}
+
+// leadConfig returns a config using the shipped lead/PM defaults, with search
+// restricted so the lead grant is the only way in.
+func leadConfig() *config.Config {
+	return &config.Config{
+		AD: config.ADConfig{
+			SearchAllowedGroups: []string{"Helpdesk"},
+			LeadGroupSuffixes:   []string{"-lead", "-pm"},
+			LeadGroupWildcard:   "-*",
+		},
+	}
+}
+
+// TestGroupMembershipHidesOutOfScopeUser is the core guarantee for user lookups: a lead
+// asking about someone outside their teams gets "not found" rather than that user's data.
+func TestGroupMembershipHidesOutOfScopeUser(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/groups/membership/outsider", nil)
+	req = mux.SetURLVars(req, map[string]string{"username": "outsider"})
+	sess := &session.Session{
+		Username: testUsername,
+		MemberOf: []string{testEngLeadDN},
+	}
+	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
+	rr := httptest.NewRecorder()
+
+	h.GroupMembership(rr, req.WithContext(ctx))
+
+	// A lead is not denied outright (that would be 403); the lookup proceeds and fails
+	// closed on the nil connection. What must never happen is a 200 exposing the target.
+	if rr.Code == http.StatusOK {
+		t.Error("an out-of-scope user lookup must not return data")
+	}
+}
+
+// TestSharesLeadScope covers the subordinate test used to gate user lookups.
+func TestSharesLeadScope(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+	sess := &session.Session{
+		Username: testUsername,
+		MemberOf: []string{testEngLeadDN},
+	}
+
+	subordinate := []string{"CN=engineering-devs,OU=Groups,DC=example,DC=com"}
+	if !h.sharesLeadScope(sess, subordinate) {
+		t.Error("a member of engineering-devs should be in an engineering lead's scope")
+	}
+
+	outsider := []string{"CN=finance-team,OU=Groups,DC=example,DC=com"}
+	if h.sharesLeadScope(sess, outsider) {
+		t.Error("a member of finance-team should be outside an engineering lead's scope")
+	}
+
+	if h.sharesLeadScope(sess, []string{"not a dn"}) {
+		t.Error("a malformed DN should not grant scope")
+	}
+}
+
+// TestFilterToLeadScope checks that out-of-scope memberships are withheld.
+func TestFilterToLeadScope(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+	sess := &session.Session{
+		Username: testUsername,
+		MemberOf: []string{testEngLeadDN},
+	}
+
+	got := h.filterToLeadScope(sess, []string{
+		"CN=engineering-devs,OU=Groups,DC=example,DC=com",
+		"CN=finance-team,OU=Groups,DC=example,DC=com",
+		"CN=engineering,OU=Groups,DC=example,DC=com",
+	})
+
+	if len(got) != 2 {
+		t.Fatalf("filterToLeadScope() = %v, want 2 in-scope groups", got)
+	}
+	for _, dn := range got {
+		if strings.Contains(dn, "finance") {
+			t.Errorf("filterToLeadScope() leaked an out-of-scope group: %q", dn)
+		}
+	}
+}
+
+func TestTeamRequiresSession(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+
+	rr := httptest.NewRecorder()
+	h.Team(rr, httptest.NewRequest(http.MethodGet, "/api/v1/team", nil))
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+// TestTeamEmptyForNonLead confirms the endpoint is inert for a user with no role: it
+// returns an empty team rather than falling through to a directory listing.
+func TestTeamEmptyForNonLead(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/team", nil)
+	sess := &session.Session{Username: testUsername, MemberOf: []string{testEmployeesDN}}
+	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
+	rr := httptest.NewRecorder()
+
+	h.Team(rr, req.WithContext(ctx))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rr.Code, http.StatusOK)
+	}
+	var resp models.TeamResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if !resp.Success {
+		t.Error("response should succeed with an empty team")
+	}
+	if len(resp.Groups) != 0 || resp.MemberCount != 0 {
+		t.Errorf("non-lead team = %+v, want empty", resp)
+	}
+}
+
+// TestSearchDeniedForPlainMember confirms non-leads outside the allow-list stay denied.
+func TestSearchDeniedForPlainMember(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/search?query=user", nil)
+	sess := &session.Session{Username: testUsername, MemberOf: []string{testEmployeesDN}}
+	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
+	rr := httptest.NewRecorder()
+
+	h.Search(rr, req.WithContext(ctx))
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
+	}
+}
+
+func TestGroupMembershipRequiresSession(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/groups/membership", nil)
+	rr := httptest.NewRecorder()
+
+	h.GroupMembership(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestGroupMembershipForbidsLookupOfOthers(t *testing.T) {
+	h := NewHandler(leadConfig(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/groups/membership/someone", nil)
+	req = mux.SetURLVars(req, map[string]string{"username": "someone"})
+	sess := &session.Session{
+		Username: testUsername,
+		MemberOf: []string{testEmployeesDN},
+	}
+	ctx := context.WithValue(req.Context(), middleware.SessionContextKey, sess)
+	rr := httptest.NewRecorder()
+
+	h.GroupMembership(rr, req.WithContext(ctx))
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want %d", rr.Code, http.StatusForbidden)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -176,6 +176,9 @@ func setupRouter(handler *handlers.Handler, sessionMgr *session.Manager, cfg *co
 
 	// Group routes
 	protected.HandleFunc("/groups", handler.GetAllGroups).Methods(http.MethodGet)
+	protected.HandleFunc("/team", handler.Team).Methods(http.MethodGet)
+	protected.HandleFunc("/groups/membership", handler.GroupMembership).Methods(http.MethodGet)
+	protected.HandleFunc("/groups/membership/{username}", handler.GroupMembership).Methods(http.MethodGet)
 	protected.HandleFunc("/groups/resolve", handler.ResolveGroups).Methods(http.MethodPost)
 	protected.HandleFunc("/groups/add-member", handler.AddUserToGroup).Methods(http.MethodPost)
 	protected.HandleFunc("/groups/remove-member", handler.RemoveUserFromGroup).Methods(http.MethodPost, http.MethodDelete)

--- a/models/models.go
+++ b/models/models.go
@@ -169,6 +169,42 @@ type GroupDetailResponse struct {
 	Error       string `json:"error,omitempty"`
 }
 
+// GroupMembershipResponse reports a user's group memberships together with the
+// leadership roles derived from them.
+type GroupMembershipResponse struct {
+	Success bool   `json:"success"`
+	Message string `json:"message,omitempty"`
+	// GroupDetails holds the LDAP details of every group the user belongs to, including
+	// groups that carry no lead or PM role.
+	GroupDetails []*Group `json:"group_details"`
+	// LeadGroupMembership holds the unique wildcard identifiers (e.g. "CN=engineering-*")
+	// of the groups in which the user is a lead or PM. Empty for a user with no role.
+	LeadGroupMembership []string `json:"lead_group_membership"`
+	Error               string   `json:"error,omitempty"`
+}
+
+// TeamGroup is one group a lead is responsible for, together with its members.
+type TeamGroup struct {
+	Group   *Group         `json:"group"`
+	Members []*GroupMember `json:"members"`
+	// Truncated reports that the directory capped this group's member list.
+	Truncated bool `json:"truncated,omitempty"`
+}
+
+// TeamResponse lists the groups the caller leads and everyone in them. It backs the
+// UI's Team view, which shows a lead their subordinates without exposing the directory.
+type TeamResponse struct {
+	Success bool         `json:"success"`
+	Message string       `json:"message,omitempty"`
+	Groups  []*TeamGroup `json:"groups"`
+	// MemberCount is the number of distinct users across all groups, so a person in
+	// two of the lead's teams is counted once.
+	MemberCount int `json:"memberCount"`
+	// LeadGroupMembership echoes the wildcard identifiers defining this scope.
+	LeadGroupMembership []string `json:"lead_group_membership"`
+	Error               string   `json:"error,omitempty"`
+}
+
 // GroupsResponse represents groups list response
 type GroupsResponse struct {
 	Success bool     `json:"success"`
@@ -198,6 +234,10 @@ type SessionInfo struct {
 	// CanSearch reports whether this session may use the search endpoint. It lets the
 	// UI hide search controls; the server-side check remains the enforcement point.
 	CanSearch bool `json:"canSearch"`
+	// LeadGroupMembership holds the wildcard identifiers of the groups in which this
+	// user is a lead or PM, so the UI can scope its search view to them. Empty when the
+	// user holds no such role.
+	LeadGroupMembership []string `json:"lead_group_membership,omitempty"`
 }
 
 // ChangeUserPasswordRequest represents a password change request

--- a/session/manager.go
+++ b/session/manager.go
@@ -188,12 +188,13 @@ func (m *Manager) GetSessionInfo(sessionID string) (*models.SessionInfo, error) 
 	}
 
 	return &models.SessionInfo{
-		SessionID: session.ID,
-		Username:  session.Username,
-		UserDN:    session.UserDN,
-		CreatedAt: session.CreatedAt,
-		ExpiresAt: session.ExpiresAt,
-		CanSearch: m.cfg.AD.IsSearchAllowedFor(session.MemberOf),
+		SessionID:           session.ID,
+		Username:            session.Username,
+		UserDN:              session.UserDN,
+		CreatedAt:           session.CreatedAt,
+		ExpiresAt:           session.ExpiresAt,
+		CanSearch:           m.cfg.AD.IsSearchAllowedFor(session.MemberOf),
+		LeadGroupMembership: m.cfg.AD.LeadGroupsFor(session.MemberOf),
 	}, nil
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -5,6 +5,7 @@ import { NotificationBanner } from './components/NotificationBanner';
 import { LoginPage } from './pages/LoginPage';
 import { UserPage } from './pages/UserPage';
 import { GroupPage } from './pages/GroupPage';
+import { TeamPage } from './pages/TeamPage';
 import { ChangePasswordPage } from './pages/ChangePasswordPage';
 
 function ProtectedRoute({ children }: { children: React.ReactNode }) {
@@ -46,6 +47,14 @@ function AppRoutes() {
         element={
           <ProtectedRoute>
             <UserPage />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/team"
+        element={
+          <ProtectedRoute>
+            <TeamPage />
           </ProtectedRoute>
         }
       />

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
-import { User, Users, Lock, LogOut } from 'lucide-react';
+import { User, Users, UsersRound, Lock, LogOut } from 'lucide-react';
 import api from '../services/api';
 import { useAuth } from '../contexts/AuthContext';
 import { useNotification } from '../contexts/NotificationContext';
@@ -8,7 +8,7 @@ import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 
 export function Sidebar() {
-  const { user, logout, isAuthenticated, canSearch } = useAuth();
+  const { user, logout, isAuthenticated, canSearch, isLead } = useAuth();
   const { showNotification } = useNotification();
   const navigate = useNavigate();
   const [version, setVersion] = useState<string | null>(null);
@@ -62,6 +62,24 @@ export function Sidebar() {
           <User className="w-5 h-5 shrink-0" />
           My Account
         </NavLink>
+
+        {/* Only leads and PMs have a team, so the tab is hidden for everyone else
+            rather than leading to an empty page. */}
+        {isLead && (
+          <NavLink
+            to="/team"
+            className={({ isActive }) =>
+              `flex items-center gap-3 px-4 py-3 text-sm font-medium transition-colors no-underline ${
+                isActive
+                  ? 'bg-sidebar-accent text-sidebar-foreground'
+                  : 'text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground'
+              }`
+            }
+          >
+            <UsersRound className="w-5 h-5 shrink-0" />
+            Team
+          </NavLink>
+        )}
 
         {/* Group browsing hits the same gated endpoints as search, so users without
             that permission are not offered a tab that can only fail. */}

--- a/web/src/contexts/AuthContext.tsx
+++ b/web/src/contexts/AuthContext.tsx
@@ -19,6 +19,12 @@ interface AuthContextType {
    * not permitted to use them. The server-side check is the real enforcement.
    */
   canSearch: boolean;
+  /**
+   * Wildcard identifiers of the groups this user leads, empty for a non-lead. Drives
+   * whether the Team tab is offered; the server re-derives the scope on every request.
+   */
+  leadGroups: string[];
+  isLead: boolean;
   login: (credentials: LoginRequest) => Promise<{ success: boolean; message?: string; status?: number }>;
   logout: () => Promise<void>;
   refreshUser: () => Promise<void>;
@@ -35,13 +41,16 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [canSearch, setCanSearch] = useState(false);
+  const [leadGroups, setLeadGroups] = useState<string[]>([]);
 
   const refreshSearchPermission = useCallback(async () => {
     try {
       const info = await api.getSessionInfo();
       setCanSearch(info?.canSearch ?? false);
+      setLeadGroups(info?.lead_group_membership ?? []);
     } catch {
       setCanSearch(false);
+      setLeadGroups([]);
     }
   }, []);
 
@@ -49,6 +58,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     if (!api.getSessionId()) {
       setUser(null);
       setCanSearch(false);
+      setLeadGroups([]);
       setIsLoading(false);
       return;
     }
@@ -63,12 +73,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
         setUser(null);
         setIsAuthenticated(false);
         setCanSearch(false);
+        setLeadGroups([]);
         api.setSessionId(null);
       }
     } catch {
       setUser(null);
       setIsAuthenticated(false);
       setCanSearch(false);
+      setLeadGroups([]);
       api.setSessionId(null);
     } finally {
       setIsLoading(false);
@@ -101,6 +113,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
       setUser(null);
       setIsAuthenticated(false);
       setCanSearch(false);
+      setLeadGroups([]);
       api.setSessionId(null);
     }
   };
@@ -112,6 +125,8 @@ export function AuthProvider({ children }: AuthProviderProps) {
         isAuthenticated,
         isLoading,
         canSearch,
+        leadGroups,
+        isLead: leadGroups.length > 0,
         login,
         logout,
         refreshUser,

--- a/web/src/pages/TeamPage.tsx
+++ b/web/src/pages/TeamPage.tsx
@@ -1,0 +1,303 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Navigate, Link } from 'react-router-dom';
+import { UsersRound, Search } from 'lucide-react';
+import { useAuth } from '../contexts/AuthContext';
+import { Sidebar } from '../components/Sidebar';
+import type { GroupMember, TeamGroup } from '../types';
+import api from '../services/api';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+/** Label used for sorting and filtering a member row. */
+function memberLabel(member: GroupMember): string {
+  return member.displayName || member.cn || member.sAMAccountName || member.dn;
+}
+
+export function TeamPage() {
+  const { isAuthenticated, isLoading, isLead, leadGroups } = useAuth();
+  const [teams, setTeams] = useState<TeamGroup[]>([]);
+  const [memberCount, setMemberCount] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoadingTeam, setIsLoadingTeam] = useState(true);
+  const [filter, setFilter] = useState('');
+
+  useEffect(() => {
+    // A non-lead has no team, and the endpoint would return an empty one, so the
+    // request is skipped entirely rather than made and discarded.
+    if (!isAuthenticated || !isLead) {
+      return;
+    }
+
+    let cancelled = false;
+
+    // Wrapped in an async function so no setState runs synchronously in the effect
+    // body: the first state update happens after the request settles.
+    const load = async () => {
+      try {
+        const response = await api.getTeam();
+        if (cancelled) {
+          return;
+        }
+        if (response.success) {
+          setTeams(response.groups ?? []);
+          setMemberCount(response.memberCount ?? 0);
+          setError(null);
+        } else {
+          setTeams([]);
+          setError(response.error || 'Failed to load your team');
+        }
+      } catch {
+        if (!cancelled) {
+          setTeams([]);
+          setError('Failed to load your team');
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoadingTeam(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isAuthenticated, isLead]);
+
+  // Filtering is client-side: the team is already bounded by the lead's scope, so it is
+  // a small list and re-querying the directory on each keystroke would be wasteful.
+  const visibleTeams = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    if (!needle) {
+      return teams;
+    }
+    return teams
+      .map((team) => ({
+        ...team,
+        members: team.members.filter((member) =>
+          [memberLabel(member), member.sAMAccountName, member.mail]
+            .filter(Boolean)
+            .some((field) => field!.toLowerCase().includes(needle))
+        ),
+      }))
+      .filter((team) => team.members.length > 0);
+  }, [teams, filter]);
+
+  const visibleCount = useMemo(() => {
+    const seen = new Set<string>();
+    for (const team of visibleTeams) {
+      for (const member of team.members) {
+        seen.add(member.dn.toLowerCase());
+      }
+    }
+    return seen.size;
+  }, [visibleTeams]);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center gap-4 flex-col text-muted-foreground">
+        <div className="w-10 h-10 rounded-full border-3 border-muted border-t-primary animate-spin" />
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/" replace />;
+  }
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <Sidebar />
+
+      <main className="flex-1 ml-64 flex flex-col h-screen overflow-hidden bg-background">
+        <header className="flex items-center justify-between px-8 py-5 bg-card border-b border-border shrink-0">
+          <div className="flex items-center gap-8 flex-1">
+            <h2 className="text-xl font-semibold text-foreground whitespace-nowrap">Team</h2>
+            {isLead && teams.length > 0 && (
+              <div className="relative flex-1 max-w-md">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
+                <Input
+                  type="text"
+                  value={filter}
+                  onChange={(e) => setFilter(e.target.value)}
+                  placeholder="Filter by name, username or email..."
+                  className="pl-9"
+                  aria-label="Filter team members"
+                />
+              </div>
+            )}
+          </div>
+        </header>
+
+        {!isLead ? (
+          <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
+            <h3 className="text-xl font-semibold text-foreground mb-2">Not available</h3>
+            <p className="text-sm text-muted-foreground">
+              You do not lead any groups, so there is no team to show.
+            </p>
+          </div>
+        ) : isLoadingTeam ? (
+          <div className="flex-1 flex flex-col items-center justify-center gap-4 text-muted-foreground">
+            <div className="w-10 h-10 rounded-full border-3 border-muted border-t-primary animate-spin" />
+            <p>Loading your team...</p>
+          </div>
+        ) : error ? (
+          <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
+            <h3 className="text-xl font-semibold text-foreground mb-2">
+              Could not load your team
+            </h3>
+            <p className="text-sm text-muted-foreground">{error}</p>
+          </div>
+        ) : teams.length === 0 ? (
+          <div className="flex-1 flex flex-col items-center justify-center text-center p-8">
+            <UsersRound className="w-10 h-10 text-muted-foreground mb-4" />
+            <h3 className="text-xl font-semibold text-foreground mb-2">No groups found</h3>
+            <p className="text-sm text-muted-foreground">
+              No groups matched {leadGroups.join(', ') || 'your leadership scope'}.
+            </p>
+          </div>
+        ) : (
+          <div className="flex-1 overflow-y-auto p-8 flex flex-col gap-6">
+            {/* Scope summary, so a lead can see which wildcards this view covers. */}
+            <Card>
+              <CardHeader className="pb-2">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <CardTitle className="text-lg">
+                    {filter.trim()
+                      ? `${visibleCount} of ${memberCount} people`
+                      : `${memberCount} ${memberCount === 1 ? 'person' : 'people'}`}
+                  </CardTitle>
+                  <div className="flex flex-wrap gap-1.5">
+                    {leadGroups.map((wildcard) => (
+                      <Badge
+                        key={wildcard}
+                        variant="outline"
+                        className="bg-primary/10 text-primary border-primary/30 font-mono text-xs"
+                      >
+                        {wildcard}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-2">
+                <p className="text-sm text-muted-foreground">
+                  Everyone in the {teams.length === 1 ? 'group' : `${teams.length} groups`} you
+                  lead. People in more than one group are counted once.
+                </p>
+              </CardContent>
+            </Card>
+
+            {visibleTeams.length === 0 ? (
+              <Card>
+                <CardContent className="py-12 text-center text-muted-foreground">
+                  No team members match "{filter}".
+                </CardContent>
+              </Card>
+            ) : (
+              visibleTeams.map((team) => (
+                <TeamGroupCard key={team.group.dn} team={team} />
+              ))
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+function TeamGroupCard({ team }: { team: TeamGroup }) {
+  const { group, members, truncated } = team;
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <CardTitle className="text-lg">
+            <Link to={`/group/${encodeURIComponent(group.cn)}`} className="hover:underline">
+              {group.cn}
+            </Link>{' '}
+            <span className="text-muted-foreground font-normal">({members.length})</span>
+          </CardTitle>
+          {truncated && (
+            <Badge
+              variant="outline"
+              className="bg-amber-50 text-amber-800 border-amber-200"
+            >
+              Showing the first {members.length} members
+            </Badge>
+          )}
+        </div>
+        {group.description && (
+          <p className="text-sm text-muted-foreground">{group.description}</p>
+        )}
+      </CardHeader>
+      <CardContent>
+        <div className="rounded-md border border-border overflow-x-auto">
+          <Table>
+            <TableHeader>
+              <TableRow className="bg-muted/50">
+                <TableHead className="font-semibold">Name</TableHead>
+                <TableHead className="font-semibold">Username</TableHead>
+                <TableHead className="font-semibold">Email</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {members.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={3} className="text-center text-muted-foreground py-8">
+                    This group has no members
+                  </TableCell>
+                </TableRow>
+              ) : (
+                members.map((member) => (
+                  <TableRow key={member.dn}>
+                    <TableCell>
+                      {member.sAMAccountName ? (
+                        <Link
+                          to={`/user/${encodeURIComponent(member.sAMAccountName)}`}
+                          className="font-medium text-primary hover:underline"
+                        >
+                          {memberLabel(member)}
+                        </Link>
+                      ) : (
+                        <span className="font-medium text-foreground">
+                          {memberLabel(member)}
+                        </span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <span className="text-muted-foreground font-mono text-xs">
+                        {member.sAMAccountName || '-'}
+                      </span>
+                    </TableCell>
+                    <TableCell>
+                      {member.mail ? (
+                        <a href={`mailto:${member.mail}`} className="text-sm">
+                          {member.mail}
+                        </a>
+                      ) : (
+                        <span className="text-muted-foreground">-</span>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -9,6 +9,7 @@ import type {
   SearchResponse,
   SessionInfo,
   HealthResponse,
+  TeamResponse,
 } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || '';
@@ -135,6 +136,25 @@ class ApiService {
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.data) {
         return error.response.data as GroupDetailResponse;
+      }
+      return {
+        success: false,
+        memberCount: 0,
+        error: error instanceof Error ? error.message : 'Unknown error occurred',
+      };
+    }
+  }
+
+  // Returns the groups the current user leads, each with its members. The scope is
+  // derived server-side from the session, so there is nothing to pass in. Errors are
+  // returned as data so the Team page can render the server's message.
+  async getTeam(): Promise<TeamResponse> {
+    try {
+      const response = await this.client.get<TeamResponse>('/api/v1/team');
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.data) {
+        return error.response.data as TeamResponse;
       }
       return {
         success: false,

--- a/web/src/test/TeamPage.test.tsx
+++ b/web/src/test/TeamPage.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { TeamPage } from '../pages/TeamPage';
+import type { TeamResponse } from '../types';
+import api from '../services/api';
+
+vi.mock('../services/api', () => ({
+  default: { getTeam: vi.fn(), getVersion: vi.fn().mockResolvedValue(null) },
+}));
+
+// The sidebar is rendered by the page but is not what these tests exercise.
+vi.mock('../components/Sidebar', () => ({ Sidebar: () => null }));
+
+let auth = {
+  isAuthenticated: true,
+  isLoading: false,
+  isLead: true,
+  leadGroups: ['CN=engineering-*'],
+};
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => auth,
+}));
+
+const teamResponse: TeamResponse = {
+  success: true,
+  memberCount: 2,
+  lead_group_membership: ['CN=engineering-*'],
+  groups: [
+    {
+      group: {
+        dn: 'CN=engineering,OU=Groups,DC=example,DC=com',
+        cn: 'engineering',
+        sAMAccountName: 'engineering',
+      },
+      members: [
+        {
+          dn: 'CN=Ann Lee,OU=Users,DC=example,DC=com',
+          cn: 'Ann Lee',
+          sAMAccountName: 'alee',
+          displayName: 'Ann Lee',
+          mail: 'alee@example.com',
+        },
+        {
+          dn: 'CN=Bob Roy,OU=Users,DC=example,DC=com',
+          cn: 'Bob Roy',
+          sAMAccountName: 'broy',
+          displayName: 'Bob Roy',
+          mail: 'broy@example.com',
+        },
+      ],
+    },
+  ],
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter>
+      <TeamPage />
+    </MemoryRouter>
+  );
+
+describe('TeamPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    auth = {
+      isAuthenticated: true,
+      isLoading: false,
+      isLead: true,
+      leadGroups: ['CN=engineering-*'],
+    };
+  });
+
+  it('lists the members of each group the user leads', async () => {
+    vi.mocked(api.getTeam).mockResolvedValue(teamResponse);
+
+    renderPage();
+
+    expect(await screen.findByText('Ann Lee')).toBeInTheDocument();
+    expect(screen.getByText('Bob Roy')).toBeInTheDocument();
+    expect(screen.getByText('engineering')).toBeInTheDocument();
+    // The distinct headcount comes from the server, not the row count.
+    expect(screen.getByText('2 people')).toBeInTheDocument();
+  });
+
+  it('filters members by name without refetching', async () => {
+    vi.mocked(api.getTeam).mockResolvedValue(teamResponse);
+
+    renderPage();
+    await screen.findByText('Ann Lee');
+
+    fireEvent.change(screen.getByLabelText('Filter team members'), {
+      target: { value: 'bob' },
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Ann Lee')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('Bob Roy')).toBeInTheDocument();
+    // Filtering is client-side over an already-scoped list.
+    expect(api.getTeam).toHaveBeenCalledTimes(1);
+  });
+
+  it('tells a non-lead there is no team rather than calling the API', async () => {
+    auth = { ...auth, isLead: false, leadGroups: [] };
+
+    renderPage();
+
+    expect(await screen.findByText('Not available')).toBeInTheDocument();
+    expect(api.getTeam).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a server error', async () => {
+    vi.mocked(api.getTeam).mockResolvedValue({
+      success: false,
+      memberCount: 0,
+      error: 'Failed to resolve team',
+    });
+
+    renderPage();
+
+    expect(await screen.findByText('Failed to resolve team')).toBeInTheDocument();
+  });
+});

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -126,6 +126,29 @@ export interface SessionInfo {
   createdAt: string;
   expiresAt: string;
   canSearch: boolean;
+  /**
+   * Wildcard identifiers (e.g. "CN=engineering-*") of the groups this user leads.
+   * Empty or absent for a user who is not a lead or PM.
+   */
+  lead_group_membership?: string[];
+}
+
+/** One group a lead is responsible for, with the users in it. */
+export interface TeamGroup {
+  group: Group;
+  members: GroupMember[];
+  /** The directory capped this group's member list. */
+  truncated?: boolean;
+}
+
+export interface TeamResponse {
+  success: boolean;
+  message?: string;
+  groups?: TeamGroup[];
+  /** Distinct users across all groups, so someone in two teams is counted once. */
+  memberCount: number;
+  lead_group_membership?: string[];
+  error?: string;
 }
 
 export interface GroupMembershipChange {


### PR DESCRIPTION
Returns every group a user belongs to, together with the groups in which they hold a lead or PM role. Prefixes are configurable